### PR TITLE
Sync hotfix with dev: Python indexing + call graph + MCP enrichments

### DIFF
--- a/.claude/commands/graph-refresh.md
+++ b/.claude/commands/graph-refresh.md
@@ -9,12 +9,13 @@ codegraph is a static snapshot of the codebase at index time. Edits after indexi
 
 ## What this does
 
-Re-parses every `.py` file under `codegraph/codegraph/` and upserts nodes / edges into Neo4j. **Does not wipe the rest of the graph** — Twenty (or any other indexed TS repos) stays untouched. Typical runtime: ~5 seconds for the codegraph package.
+Re-parses every `.py` file under `codegraph/codegraph/` and `codegraph/tests/` and upserts nodes / edges into Neo4j. **Does not wipe the rest of the graph** — Twenty (or any other indexed TS repos) stays untouched. Typical runtime: ~5 seconds for both packages.
 
 ```bash
 codegraph/.venv/bin/codegraph index \
     /home/edouard-gouilliard/Obsidian/SecondBrain/Personal/projects/graphrag-code \
     -p codegraph/codegraph \
+    -p codegraph/tests \
     --no-wipe \
     --skip-ownership
 ```

--- a/.claude/commands/graph-refresh.md
+++ b/.claude/commands/graph-refresh.md
@@ -1,0 +1,36 @@
+---
+allowed-tools: Bash(codegraph/.venv/bin/codegraph index:*), Bash(.venv/bin/codegraph index:*), Bash(codegraph index:*)
+description: Re-index the codegraph Python package so /graph queries reflect the latest on-disk state
+---
+
+## Why
+
+codegraph is a static snapshot of the codebase at index time. Edits after indexing don't show up in the graph until you re-index. Run this command after any **structural** change — adding/removing classes, functions, methods, imports, decorators; renaming; moving files. For cosmetic edits (comment changes, reformatting), it's not necessary.
+
+## What this does
+
+Re-parses every `.py` file under `codegraph/codegraph/` and upserts nodes / edges into Neo4j. **Does not wipe the rest of the graph** — Twenty (or any other indexed TS repos) stays untouched. Typical runtime: ~5 seconds for the codegraph package.
+
+```bash
+codegraph/.venv/bin/codegraph index \
+    /home/edouard-gouilliard/Obsidian/SecondBrain/Personal/projects/graphrag-code \
+    -p codegraph/codegraph \
+    --no-wipe \
+    --skip-ownership
+```
+
+`--no-wipe` keeps other graphs alive. `--skip-ownership` skips the git-log pass (faster; owners can be added back later if needed).
+
+## After running
+
+Re-run any `/graph` queries you had open — results should reflect the latest code. If something unexpected disappeared, it's more likely a parser edge case than a data loss: check the AST of the file in question, or open an issue.
+
+## Indexing a different repo
+
+To point the graph at some other TS / Python repo:
+
+```bash
+codegraph/.venv/bin/codegraph index /path/to/repo -p <package>
+```
+
+Drop `--no-wipe` if you want to start from a clean graph (wipes everything, including the codegraph + Twenty snapshots).

--- a/.claude/commands/graph.md
+++ b/.claude/commands/graph.md
@@ -1,0 +1,88 @@
+---
+allowed-tools: Bash(codegraph query:*), Bash(codegraph/.venv/bin/codegraph query:*), Bash(.venv/bin/codegraph query:*)
+description: Run a read-only Cypher query against the live codegraph Neo4j graph
+---
+
+## Usage
+
+```
+/graph <cypher>
+```
+
+Runs the Cypher against the local Neo4j instance via `codegraph query --json`. Read-only — writes (`CREATE`, `MERGE`, `DELETE`, `SET`) are **not** rejected at the CLI level (unlike the MCP server), so be careful what you execute. If you're unsure, stick to `MATCH` queries.
+
+Assumes:
+- Neo4j is up at `bolt://localhost:7688` (`docker compose up -d` from `codegraph/` if not).
+- The graph has been indexed at least once (run `/graph-refresh` if you get zero results on queries you expect to match).
+
+## Canonical query patterns for this repo
+
+The graph is currently indexed for `codegraph/codegraph/` (the Python package) — ~18 files, 41 classes, 82 module functions, ~150 methods, decorators via `:Decorator` nodes, imports via `IMPORTS` / `IMPORTS_SYMBOL` / `IMPORTS_EXTERNAL` edges.
+
+### Blast radius — who depends on a file?
+
+```cypher
+MATCH (f:File)-[:IMPORTS]->(target:File {path: 'codegraph/codegraph/schema.py'})
+RETURN f.path AS caller
+ORDER BY f.path
+```
+
+### Who imports a specific symbol?
+
+```cypher
+MATCH (f:File)-[r:IMPORTS_SYMBOL]->(g:File)
+WHERE r.symbol = 'IgnoreFilter'
+RETURN f.path AS caller, g.path AS source
+```
+
+### Find a class by substring
+
+```cypher
+MATCH (c:Class)
+WHERE c.name CONTAINS 'Node' AND c.file STARTS WITH 'codegraph/codegraph/'
+RETURN c.name, c.file
+ORDER BY c.name
+```
+
+### Methods on a class
+
+```cypher
+MATCH (c:Class {name: 'IgnoreFilter'})-[:HAS_METHOD]->(m:Method)
+RETURN m.name, m.visibility, m.is_constructor
+ORDER BY m.name
+```
+
+### Census of dataclasses
+
+```cypher
+MATCH (f:File)-[:DEFINES_CLASS]->(c:Class)-[:DECORATED_BY]->(d:Decorator {name: 'dataclass'})
+WHERE f.path STARTS WITH 'codegraph/codegraph/'
+RETURN f.path, count(c) AS dataclass_count
+ORDER BY dataclass_count DESC
+```
+
+### What decorators does a file use?
+
+```cypher
+MATCH (:File {path: 'codegraph/codegraph/mcp.py'})-[:DEFINES_FUNC]->(fn:Function)-[:DECORATED_BY]->(d:Decorator)
+RETURN fn.name, d.name
+ORDER BY fn.name
+```
+
+### Unresolved (external) imports from a file
+
+```cypher
+MATCH (:File {path: 'codegraph/codegraph/cli.py'})-[r:IMPORTS {external: true}]->(e:External)
+RETURN e.specifier
+ORDER BY e.specifier
+```
+
+## Running it
+
+Invoke with a single Cypher string as argument. The command runs from the repo root:
+
+```bash
+codegraph/.venv/bin/codegraph query --json "$ARGUMENTS"
+```
+
+The `--json` output makes the response machine-parseable if you're planning follow-up queries. Drop `--json` for a rendered Rich table.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(codegraph:*)",
+      "Bash(codegraph query:*)",
+      "Bash(codegraph index:*)",
+      "Bash(codegraph validate:*)",
+      "Bash(codegraph/.venv/bin/codegraph:*)",
+      "Bash(.venv/bin/codegraph:*)",
+      "Bash(python -m codegraph.cli:*)",
+      "Bash(python -m compileall:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(pip install:*)",
+      "Bash(docker:*)",
+      "Bash(docker compose:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ Thumbs.db
 # Neo4j local data (if anyone binds the volume locally)
 neo4j/data/
 neo4j/logs/
+
+# Claude Code — ship .claude/settings.json + .claude/commands/, keep the
+# rest user-local. `.local` settings are per-user overrides by convention;
+# agents/ and skills/ are copied in per-user by init-claude.
+.claude/settings.local.json
+.claude/agents/
+.claude/skills/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,15 +30,15 @@ Read-only Cypher against `bolt://localhost:7688`. Prefer this over manual `codeg
 
 ### `/graph-refresh` — update the graph
 
-Re-indexes this repo's Python package (`codegraph/codegraph/`) so `/graph` queries reflect the latest on-disk state. **Run it after any structural edit** — adding, removing, renaming, or moving classes / functions / methods / imports / decorators. Cosmetic edits don't need a refresh.
+Re-indexes this repo's Python package + its tests (`codegraph/codegraph/` + `codegraph/tests/`) so `/graph` queries reflect the latest on-disk state. **Run it after any structural edit** — adding, removing, renaming, or moving classes / functions / methods / imports / decorators. Cosmetic edits don't need a refresh.
 
 Takes ~5 seconds. Uses `--no-wipe` so other indexed graphs (e.g. Twenty) survive. See `.claude/commands/graph-refresh.md`.
 
 ### What's indexed (and what isn't)
 
-The slash commands point at `codegraph/codegraph/` — the Python package. That's ~18 files, 41 classes, 82 module functions, ~150 methods, all their decorators, and their intra-package imports. **Not indexed**: `codegraph/tests/`, the root-level `dependency_slicer.py`, `.venv`, the repo root's config files.
+The slash commands point at `codegraph/codegraph/` (the Python package) and `codegraph/tests/` (its test suite). The package is ~18 files, 41 classes, 82 module functions, ~150 methods; tests add another handful of files that pair back via `TESTS` edges where they share a directory with their production peer. **Not indexed**: the root-level `dependency_slicer.py`, `.venv`, the repo root's config files.
 
-If you want a query against tests or other paths, re-run `codegraph/.venv/bin/codegraph index . -p <path>` with the package scope you want.
+If you want a query against other paths, re-run `codegraph/.venv/bin/codegraph index . -p <path>` with the package scope you want.
 
 ### Prerequisites
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and similar coding agents) working on this repo.
+
+## Project summary
+
+**codegraph** (package: `codegraph`) is a Python tool that indexes TypeScript and Python codebases into a Neo4j property graph. It walks source with tree-sitter, recognises framework constructs (NestJS controllers / injectables / modules, React components and hooks, TypeORM entities, GraphQL operations, Python classes and decorators), and loads typed nodes + edges into Neo4j. Downstream consumers:
+
+- **CLI**: `codegraph index`, `codegraph query`, `codegraph validate`, `codegraph wipe` — Typer app.
+- **MCP server**: `codegraph-mcp` stdio server with 10 read-only tools. Optional extra (`pip install "codegraph[mcp]"`).
+- **REPL**: interactive Cypher shell at `codegraph repl`.
+
+This repo is itself **Python**, and codegraph parses Python since Stage 1 shipped. So we can dogfood: Claude Code can query the graph of codegraph-the-codebase while implementing codegraph-the-tool.
+
+## Using the graph during development
+
+Two slash commands wire the local Neo4j graph into your Claude Code workflow. **Use them** — they exist to catch mistakes the language server can't.
+
+### `/graph <cypher>` — query the live graph
+
+Read-only Cypher against `bolt://localhost:7688`. Prefer this over manual `codegraph query` in Bash because the slash command has the permissions pre-approved and a body of canonical query patterns. See `.claude/commands/graph.md` for examples.
+
+**When to run `/graph`**:
+
+- **Before renaming** a class, function, or file → check blast radius with `MATCH (f:File)-[r:IMPORTS_SYMBOL]->(g:File) WHERE r.symbol = 'X' RETURN f.path, g.path`.
+- **Before deleting** a function or method → confirm nothing depends on it.
+- **Before moving** a module → count incoming IMPORTS edges; you'll need to update every caller.
+- **When asked "who calls X?" or "where is Y used?"** — almost always a one-query answer.
+- **When in doubt about what exists** — `/graph "MATCH (c:Class) WHERE c.name CONTAINS 'Foo' RETURN c.name, c.file"` is faster and more exhaustive than grep.
+
+### `/graph-refresh` — update the graph
+
+Re-indexes this repo's Python package (`codegraph/codegraph/`) so `/graph` queries reflect the latest on-disk state. **Run it after any structural edit** — adding, removing, renaming, or moving classes / functions / methods / imports / decorators. Cosmetic edits don't need a refresh.
+
+Takes ~5 seconds. Uses `--no-wipe` so other indexed graphs (e.g. Twenty) survive. See `.claude/commands/graph-refresh.md`.
+
+### What's indexed (and what isn't)
+
+The slash commands point at `codegraph/codegraph/` — the Python package. That's ~18 files, 41 classes, 82 module functions, ~150 methods, all their decorators, and their intra-package imports. **Not indexed**: `codegraph/tests/`, the root-level `dependency_slicer.py`, `.venv`, the repo root's config files.
+
+If you want a query against tests or other paths, re-run `codegraph/.venv/bin/codegraph index . -p <path>` with the package scope you want.
+
+### Prerequisites
+
+The slash commands silently assume:
+1. Neo4j is running: `docker ps | grep codegraph-neo4j` should show a healthy container. If not, `cd codegraph && docker compose up -d`.
+2. The `.venv` is installed with the `[python]` extra: `codegraph/.venv/bin/codegraph --help` should work. If not, `cd codegraph && python3 -m venv .venv && .venv/bin/pip install -e ".[python,mcp]"`.
+3. The graph has been indexed at least once. Run `/graph-refresh` if `/graph` returns zero for queries you expect to match.
+
+## Repo conventions
+
+- **Branches**: `dev` is where work lands. `main` / `release` / `hotfix` are protected; PRs from `dev` to `main`.
+- **Atomic commits** with detailed bodies. See `git log` for the style. Subjects follow conventional commits (`feat(scope)`, `fix(scope)`, `docs(scope)`, `test(scope)`).
+- **Tests**: `.venv/bin/python -m pytest tests/ -q` from `codegraph/`. Target 100% passing, zero warnings. The suite runs in ~15s.
+- **Type checking**: none configured today; we rely on the tests + `python -m compileall` for basic integrity.
+- **Linting**: none configured today either.
+- **Planning**: non-trivial changes go through `/plan_local` (or manual plan-mode) before implementation. Plans live at `~/.claude/plans/`.
+- **`.claude/` layout**: `.claude/commands/` contains repo-shared slash commands (committed). `.claude/settings.json` holds repo-shared permissions (committed). `.claude/settings.local.json`, `.claude/agents/`, and `.claude/skills/` are user-local (gitignored).
+
+## Architecture at a glance
+
+Read `ROADMAP.md` at the repo root for the session-to-session handoff and the full state of the codebase (shipped features per commit, open questions, what's next, environment setup, tests, architectural decisions). It's the authoritative pointer.
+
+Key source files:
+
+| File | Purpose |
+|---|---|
+| `codegraph/codegraph/cli.py` | Typer CLI + file-walk dispatch (TS ↔ Python) |
+| `codegraph/codegraph/parser.py` | TypeScript / TSX tree-sitter walker |
+| `codegraph/codegraph/py_parser.py` | Python tree-sitter walker |
+| `codegraph/codegraph/resolver.py` | Cross-file import resolution (TS + Python) |
+| `codegraph/codegraph/loader.py` | Neo4j batch writer + constraints |
+| `codegraph/codegraph/schema.py` | Node + edge dataclasses (language-agnostic) |
+| `codegraph/codegraph/mcp.py` | FastMCP stdio server (10 tools) |
+| `codegraph/codegraph/framework.py` | Per-package framework detection (TS only in Stage 1) |
+| `codegraph/codegraph/ignore.py` | `.codegraphignore` parser |
+| `codegraph/codegraph/config.py` | `codegraph.toml` / `pyproject.toml` config loader |
+
+## Non-goals to remember
+
+- Don't refactor `TsParser` to be "language-agnostic" — two concrete parsers with the same `ParseResult` interface is the chosen design. See commit `154954c` for the rationale.
+- Don't commit `.claude/settings.local.json`, `.claude/agents/`, or `.claude/skills/`. They're user-local agent config.
+- Don't add per-file framework flags to Python FileNodes beyond what Stage 1 emits. Framework detection for Python lands in Stage 2 as a separate piece.
+- Don't work on Go / Rust frontends until Stage 2/3 of the Python frontend has landed — priority is depth over breadth for now.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ docker compose up -d
 
 | Kind | Examples / notes |
 | --- | --- |
-| `Package` | One per configured monorepo package with detected `framework`, `framework_version`, `typescript`, `styling`, `router`, `state_management`, `ui_library`, `build_tool`, `package_manager`, and a detection `confidence` |
+| `Package` | One per configured monorepo package with detected `framework` (React / Next.js / Vue / Angular / Svelte / SvelteKit / **NestJS** / Odoo), `framework_version`, `typescript`, `styling`, `router`, `state_management`, `ui_library`, `build_tool`, `package_manager`, and a detection `confidence`. Framework detection walks up to the monorepo root for lockfiles + workspace-hoisted dependencies. |
 | `File` | TS/TSX files with language, LOC, and framework flags (`is_controller`, `is_component`, …) |
 | `Class` | NestJS controllers, injectables, modules, entities, resolvers |
 | `Function` | Exported functions and React components |

--- a/README.md
+++ b/README.md
@@ -106,9 +106,11 @@ docker compose up -d
 # Browser UI:  http://localhost:7475   (neo4j / codegraph123)
 # Bolt:        bolt://localhost:7688
 
-# 3. Index a repo (scoped to the packages you care about)
+# 3. Tell codegraph which packages in your monorepo to index.
+#    Either drop a codegraph.toml at the repo root (see Configuration below)
+#    or pass --package flags:
 .venv/bin/python -m codegraph.cli index /path/to/your-monorepo \
-  --package twenty-server --package twenty-front
+  --package packages/server --package packages/web
 
 # 4. Sanity-check the load
 .venv/bin/python -m codegraph.cli validate /path/to/your-monorepo
@@ -165,7 +167,44 @@ See [`codegraph/queries.md`](codegraph/queries.md) for the full catalogue.
 
 ## ⚙️ Configuration
 
-Neo4j connection is controlled via environment variables (defaults match the bundled Docker Compose):
+### Project config — `codegraph.toml`
+
+`codegraph` has **no hardcoded packages**. You tell it which packages to index via a `codegraph.toml` at the repo root, a `[tool.codegraph]` block in your existing `pyproject.toml`, or `--package` flags on the CLI. Config file values are loaded first; CLI flags override them.
+
+**`codegraph.toml`** (preferred — a standalone file, no interference with Python tooling):
+
+```toml
+# Paths are relative to the repo root. Each entry should be a TypeScript
+# package directory (i.e. contain a package.json / tsconfig.json so path
+# aliases can be resolved).
+packages = [
+  "packages/server",
+  "packages/web",
+]
+
+# Optional — these extend the built-in defaults, they don't replace them.
+exclude_dirs     = ["custom-build", "fixtures"]
+exclude_suffixes = [".gen.ts"]
+```
+
+**`pyproject.toml`** (if you already have one and want everything in one place):
+
+```toml
+[tool.codegraph]
+packages = ["packages/server", "packages/web"]
+```
+
+**CLI override** — wins over either file:
+
+```bash
+codegraph index . --package packages/server --package packages/web
+```
+
+If no config file exists and no `--package` flags are passed, `index` stops with a clear error. There are no Twenty-specific or other defaults.
+
+### Neo4j connection
+
+Controlled via environment variables (defaults match the bundled `docker-compose.yml`):
 
 | Variable | Default |
 | --- | --- |
@@ -173,7 +212,9 @@ Neo4j connection is controlled via environment variables (defaults match the bun
 | `CODEGRAPH_NEO4J_USER` | `neo4j` |
 | `CODEGRAPH_NEO4J_PASS` | `codegraph123` |
 
-Indexing excludes `node_modules`, `dist`, `build`, `.next`, `.turbo`, `coverage`, generated directories, and test/story/declaration files by default. Override with `--package` to scope to specific monorepo packages.
+### File walk exclusions
+
+Indexing always skips `node_modules`, `dist`, `build`, `.next`, `.turbo`, `.nuxt`, `.svelte-kit`, `.vercel`, `coverage`, `generated`, `__generated__`, `.cache`, `.parcel-cache`, plus `*.d.ts` and `*.stories.{ts,tsx}`. Add to these via `exclude_dirs` / `exclude_suffixes` in your config — those keys **extend** the defaults, they don't replace them.
 
 ## 🛣️ Roadmap
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,13 @@ Restart Claude Code. Five tools become available:
 | `list_packages()` | Every indexed monorepo package with its detected framework, version, TypeScript flag, package manager, and detection confidence. |
 | `callers_of_class(class_name, max_depth)` | Blast-radius traversal over `INJECTS` / `EXTENDS` / `IMPLEMENTS`. The canonical "what breaks if I rename X" query. |
 | `endpoints_for_controller(controller_name)` | HTTP routes exposed by a NestJS controller class (method + path + handler). |
+| `files_in_package(name, limit)` | List files belonging to a `:Package` by name. |
+| `hook_usage(hook_name, limit)` | Which components / functions use a given React hook. |
+| `gql_operation_callers(op_name, op_type, limit)` | Who calls a GraphQL query / mutation / subscription, optionally narrowed by type. |
+| `most_injected_services(limit)` | Rank `@Injectable` classes by number of unique callers — the classic "DI hub detection" query. |
+| `find_class(name_pattern, limit)` | Case-sensitive substring search over class names, backed by the `class_name` index. |
 
-All five tools share a single long-lived Neo4j driver and open sessions in `READ_ACCESS` mode. Configuration is env-var only (the same `CODEGRAPH_NEO4J_*` vars the CLI uses). The server is stdio-only — no network exposure.
+All ten tools share a single long-lived Neo4j driver and open sessions in `READ_ACCESS` mode. Configuration is env-var only (the same `CODEGRAPH_NEO4J_*` vars the CLI uses). The server is stdio-only — no network exposure.
 
 ## 🏗️ Architecture
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,24 @@ codegraph index . --package packages/server --package packages/web
 
 If no config file exists and no `--package` flags are passed, `index` stops with a clear error. There are no Twenty-specific or other defaults.
 
+### Python support (`.py` indexing)
+
+codegraph also indexes Python codebases. The detector auto-picks the language based on the package directory: if the directory contains `__init__.py`, it's parsed as Python; otherwise it's parsed as TypeScript (with `tsconfig.json` / `package.json`).
+
+Install the optional `[python]` extra to enable the Python frontend:
+
+```bash
+pip install "codegraph[python]"
+```
+
+Then point `--package` at a Python package root (the directory containing `__init__.py`):
+
+```bash
+codegraph index . --package src/my_package
+```
+
+Stage 1 indexes: modules (`.py` files), classes, functions, methods, imports (relative + absolute + `import x as y`), class inheritance, and decorators. Framework detection (FastAPI / Flask / Django / Typer / pytest) and route extraction land in Stage 2.
+
 ### Neo4j connection
 
 Controlled via environment variables (defaults match the bundled `docker-compose.yml`):

--- a/README.md
+++ b/README.md
@@ -216,6 +216,27 @@ Controlled via environment variables (defaults match the bundled `docker-compose
 
 Indexing always skips `node_modules`, `dist`, `build`, `.next`, `.turbo`, `.nuxt`, `.svelte-kit`, `.vercel`, `coverage`, `generated`, `__generated__`, `.cache`, `.parcel-cache`, plus `*.d.ts` and `*.stories.{ts,tsx}`. Add to these via `exclude_dirs` / `exclude_suffixes` in your config — those keys **extend** the defaults, they don't replace them.
 
+### `.codegraphignore`
+
+For **confidential routes, components, or files** that shouldn't reach the graph (and therefore shouldn't reach any LLM agent querying it), drop a `.codegraphignore` file at the repo root. Syntax is gitignore-style, plus two codegraph extensions:
+
+```gitignore
+# Standard gitignore — file paths
+**/admin/**
+**/*.secret.ts
+!**/admin/public/**         # negation — re-include a subtree
+
+# Route patterns — match RouteNode.path
+@route:/admin/*
+@route:/settings/system/*
+
+# Component patterns — match React component / NestJS class names
+@component:*Admin*
+@component:*UserManagement*
+```
+
+Override the default location with `--ignore-file PATH` on the CLI or `ignore_file = "custom/.ignore"` in `codegraph.toml`. `.codegraphignore` is **additive** on top of `BASE_EXCLUDE_DIRS` — it doesn't replace them.
+
 ## 🛣️ Roadmap
 
 - Incremental re-indexing on file changes

--- a/README.md
+++ b/README.md
@@ -71,11 +71,41 @@ All answered in single-digit milliseconds, with zero tokens spent on retrieving 
 
 ### Exposing the graph to Claude via MCP
 
-A first-class **[Model Context Protocol](https://modelcontextprotocol.io/)** server wrapping the graph is on the [Roadmap](#-roadmap). In the meantime, you can:
+codegraph ships a first-class **[Model Context Protocol](https://modelcontextprotocol.io/)** stdio server. Install the optional extra, add one block to Claude Code's config, and five typed tools appear in the agent's tool menu — no more shelling out to `codegraph query`.
 
-- Let Claude Code shell out to `codegraph query "<cypher>"` via its bash tool.
-- Write a small MCP server that exposes a `query_graph` tool backed by the Neo4j driver.
-- Query Bolt directly from any agent framework that supports custom tools.
+```bash
+pip install "codegraph[mcp]"
+```
+
+In `~/.claude.json` (or your Claude Desktop config):
+
+```json
+{
+  "mcpServers": {
+    "codegraph": {
+      "command": "codegraph-mcp",
+      "type": "stdio",
+      "env": {
+        "CODEGRAPH_NEO4J_URI":  "bolt://localhost:7688",
+        "CODEGRAPH_NEO4J_USER": "neo4j",
+        "CODEGRAPH_NEO4J_PASS": "codegraph123"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Code. Five tools become available:
+
+| Tool | Purpose |
+| --- | --- |
+| `query_graph(cypher, limit)` | Read-only Cypher escape hatch. Writes are rejected at the session level, so an LLM-generated `DROP`/`DELETE` can't mutate the graph. |
+| `describe_schema()` | Labels, relationship types, and per-label node counts — cheap way for an agent to learn what's in the graph at session start. |
+| `list_packages()` | Every indexed monorepo package with its detected framework, version, TypeScript flag, package manager, and detection confidence. |
+| `callers_of_class(class_name, max_depth)` | Blast-radius traversal over `INJECTS` / `EXTENDS` / `IMPLEMENTS`. The canonical "what breaks if I rename X" query. |
+| `endpoints_for_controller(controller_name)` | HTTP routes exposed by a NestJS controller class (method + path + handler). |
+
+All five tools share a single long-lived Neo4j driver and open sessions in `READ_ACCESS` mode. Configuration is env-var only (the same `CODEGRAPH_NEO4J_*` vars the CLI uses). The server is stdio-only — no network exposure.
 
 ## 🏗️ Architecture
 
@@ -242,7 +272,7 @@ Override the default location with `--ignore-file PATH` on the CLI or `ignore_fi
 
 - Incremental re-indexing on file changes
 - Python and Go language frontends
-- First-class MCP server exposing the graph to LLM agents
+- ~~First-class MCP server exposing the graph to LLM agents~~ — **shipped** (see [Exposing the graph to Claude via MCP](#exposing-the-graph-to-claude-via-mcp))
 - Pre-built RAG retrievers for common architecture questions
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ docker compose up -d
 
 | Kind | Examples / notes |
 | --- | --- |
+| `Package` | One per configured monorepo package with detected `framework`, `framework_version`, `typescript`, `styling`, `router`, `state_management`, `ui_library`, `build_tool`, `package_manager`, and a detection `confidence` |
 | `File` | TS/TSX files with language, LOC, and framework flags (`is_controller`, `is_component`, …) |
 | `Class` | NestJS controllers, injectables, modules, entities, resolvers |
 | `Function` | Exported functions and React components |
@@ -137,7 +138,7 @@ docker compose up -d
 
 **Edges**
 
-`IMPORTS`, `IMPORTS_EXTERNAL`, `DEFINES_CLASS`, `DEFINES_FUNC`, `DEFINES_IFACE`, `EXPOSES`, `INJECTS`, `EXTENDS`, `IMPLEMENTS`, `RENDERS`, `USES_HOOK`, `DECORATED_BY`.
+`IMPORTS`, `IMPORTS_EXTERNAL`, `DEFINES_CLASS`, `DEFINES_FUNC`, `DEFINES_IFACE`, `EXPOSES`, `INJECTS`, `EXTENDS`, `IMPLEMENTS`, `RENDERS`, `USES_HOOK`, `DECORATED_BY`, `BELONGS_TO` (File → Package).
 
 ## 🔎 Example queries
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,463 @@
+# codegraph — Roadmap & Session Handoff
+
+> **Purpose of this document.** Capture enough context for a fresh agent session (or a human returning after time away) to continue work on codegraph without re-deriving state from scratch. Separate from the user-facing roadmap bullets in `README.md`, which stay short and pitch-oriented.
+>
+> **Last updated:** 2026-04-15 after commit `7588522`.
+
+---
+
+## TL;DR — where we are
+
+- **Branch:** `dev` (pushed to `origin/dev`). Six commits ahead of `main`, not yet PR'd.
+- **Tests:** 103/103 passing, 0 warnings. Run via `.venv/bin/python -m pytest tests/` from inside `codegraph/`.
+- **Graph indexed:** Twenty CRM (`/tmp/twenty`, 13460 TS/TSX files) is loaded into the local Neo4j container. Good integration target.
+- **MCP server:** 10 read-only tools live. `codegraph-mcp` console script registered. End-to-end verified via JSON-RPC against the live Twenty graph.
+- **Nothing pushed to `main`.** Whole session's work sits on `dev`.
+
+---
+
+## Shipped this session (six atomic commits on `dev`)
+
+```
+7588522 feat(mcp):   add 5 pre-built retrievers for common agent questions
+39be5c2 fix(review): address code-reviewer findings across mcp, framework, tests
+e7382f7 fix(framework): detect NestJS, walk up for lockfile + workspace deps
+c198c5d feat(mcp):   stdio server with 5 read-only tools
+9fb4d1d feat(schema): per-package framework detection + :Package nodes
+b71bc45 feat(ignore): .codegraphignore for per-repo file/route/component exclusion
+```
+
+All six commits came from porting pieces of `/tmp/agent-onboarding/architect/` (a related internal repo, Apache-2.0) and then hardening them against real monorepo shapes via an end-to-end test on Twenty CRM.
+
+### What each commit added
+
+**`b71bc45 feat(ignore)`** — `codegraph/codegraph/ignore.py` (new, ~180 LOC).
+- Parses `.codegraphignore` at repo root (or via `--ignore-file` CLI flag).
+- Syntax: gitignore-style file globs + `@route:/admin/*` + `@component:*Admin*` + `!` negation.
+- Hooked into `cli._run_index` at three points: file walk (skip file), `_extract_routes` (skip RouteNode), and a new `_strip_ignored_components` pass (flip `FunctionNode.is_component = False` without deleting the function — preserves IMPORTS/CALL edges).
+- Stripped from the upstream: opinionated `DEFAULT_IGNORE_PATTERNS`, `save_agentignore` / `create_default_agentignore` UX helpers.
+- Renamed `.agentignore` → `.codegraphignore` to match tool convention and avoid clashing if users run both projects.
+- 12 unit tests in `codegraph/tests/test_ignore.py` (plus 7 more added later for `_strip_ignored_components` + `_load_ignore_filter` helpers).
+
+**`9fb4d1d feat(schema)`** — `codegraph/codegraph/framework.py` (new, ~360 LOC originally).
+- `FrameworkDetector` class with scored heuristic: file existence (30 pts) + package.json dep (25 pts) + code-regex pattern (15 pts) per framework.
+- Initial frameworks: React / React-TS / Next.js / Vue / Vue3 / Angular / Svelte / SvelteKit / Odoo (+ Unknown).
+- New `:Package` node in `schema.py` with all `FrameworkInfo` fields inlined: `name`, `framework`, `framework_version`, `typescript`, `styling`, `router`, `state_management`, `ui_library`, `build_tool`, `package_manager`, `confidence`.
+- New `:BELONGS_TO` edge type (File → Package) + `_write_packages` / `_write_belongs_to` functions in `loader.py`.
+- `LoadStats` extended with `packages` and `belongs_to_edges` counters.
+- `Index.packages: list[PackageNode]` added to `resolver.py`.
+- `FrameworkDetector(pkg_dir).detect()` runs once per configured package in `cli._run_index` right after `load_package_config`.
+- 14 unit tests against 6 fixture apps bundled with agent-onboarding (`/tmp/agent-onboarding/tests/fixtures/{react,nextjs,vue,sveltekit,angular,odoo}-app`).
+- 3 new example queries in `codegraph/queries.md`.
+
+**`c198c5d feat(mcp)`** — `codegraph/codegraph/mcp.py` (new, ~240 LOC originally).
+- FastMCP (`mcp>=1.0`) stdio server registered as `codegraph-mcp` console script via `pyproject.toml`.
+- `mcp` is an **optional extra** — `pip install "codegraph[mcp]"`. Main CLI unaffected if not installed.
+- Five initial tools: `query_graph`, `describe_schema`, `list_packages`, `callers_of_class`, `endpoints_for_controller`.
+- Module-scoped Neo4j driver (started as eager, made lazy in a later commit — see `39be5c2`).
+- Every session opened with `default_access_mode=neo4j.READ_ACCESS` → Neo4j rejects any `CREATE`/`MERGE`/`DELETE`/`SET` at the session level. Verified live: a `DETACH DELETE (f:File)` attempt returned `[{"error": "Writing in read access mode not allowed"}]` and the 13460 file count stayed unchanged.
+- Extracted `clean_row` helper to `codegraph/codegraph/utils/neo4j_json.py` so both cli and mcp share it.
+- 18 unit tests in `codegraph/tests/test_mcp.py` with a `FakeDriver`/`FakeSession`/`FakeRecord` pattern — no real Neo4j needed for tests.
+- README section "Exposing the graph to Claude via MCP" filled in with concrete install + config snippet.
+
+**`e7382f7 fix(framework)`** — detector hardening driven by the Twenty e2e test.
+- Twenty end-to-end revealed three bugs: twenty-server mis-labeled as "React TS 65%" instead of NestJS, twenty-front at only 30% confidence (hoisted deps invisible), and `package_manager=null` on both packages (lockfile at monorepo root, not package root).
+- Added `FrameworkType.NESTJS` + `nest-cli.json` / `@nestjs/core` / `@Module|@Injectable|@Controller` indicators. NestJS scores 125 raw points on a real NestJS package vs React's ~80, so it wins the `max(scores)` decisively.
+- New `_walk_up_to_repo_root(max_hops=10)` iterator — yields `project_path` then each parent, stops at a `.git` entry or filesystem root.
+- Rewrote `_detect_package_manager` to walk up for lockfiles.
+- New `_workspace_dependencies` property that merges own `package.json` deps + any parent `package.json` found walking up **whose manifest declares a `workspaces` field**. The workspaces guard prevents leakage from unrelated enclosing projects.
+- 9 new tests including 2 opt-in integration tests against `/tmp/twenty` that skip cleanly if the clone is missing.
+
+**`39be5c2 fix(review)`** — code-reviewer round 1+2 fixes.
+- **Lazy `_driver`.** `mcp._driver` is now `Optional[Driver]`; a new `_get_driver()` constructs it on first tool call. `import codegraph.mcp` no longer touches Neo4j. `main()` closes the driver only if constructed.
+- **`describe_schema` error routing.** Was dereferencing `e.message` directly — `None` on ad-hoc `Neo4jError` instances. Now routes through the shared `_err_msg` like every other tool.
+- **Shared `_workspace_package_jsons()` cache** in `framework.py`. Both `_workspace_dependencies` and `_get_dependency_version` consume one parse-once cache instead of each re-walking and re-parsing on every call. Closes an N × depth disk-read cost on deep monorepos.
+- **Defensive `copy.deepcopy` of own `package_json`** in the workspace cache so iteration-site mutation can't corrupt `self._package_json`.
+- **`_FakeSession.run` always-pops** in the test fake (was conditional — would silently reuse the last response on a 4+ call).
+- +9 new tests: describe_schema error paths, `_strip_ignored_components`, `_load_ignore_filter` resolution branches (default auto-detect, no-config-no-default, explicit-missing-relative, explicit-missing-absolute).
+- Three review rounds total; round 3 returned "clean".
+
+**`7588522 feat(mcp)`** — 5 additional pre-built retrievers.
+- `files_in_package(name, limit=50)` — uses `(f:File {package:$name})` directly via the existing `file_package` property index.
+- `hook_usage(hook_name, limit=50)` — `(Function)-[:USES_HOOK]->(Hook)`, `DISTINCT` to dedupe multiple call sites, returns `is_component` flag for agent triage.
+- `gql_operation_callers(op_name, op_type=None, limit=50)` — optional filter to `{query, mutation, subscription}`. `labels(caller)[0]` returned as `caller_kind`.
+- `most_injected_services(limit=20, max=100)` — the canonical "DI hub detection" query. `count(DISTINCT caller)` so a caller injecting into multiple methods counts once.
+- `find_class(name_pattern, limit=50)` — case-sensitive `CONTAINS` backed by the `class_name` range index. Empty pattern rejected explicitly.
+- Shared `_validate_limit(limit, max_limit=1000)` helper. Rejects non-int (including `bool`, because `bool` is an `int` subclass in Python) before any Cypher is built. **Limits are validated-then-interpolated because Neo4j 5.x rejects `LIMIT $param` as a syntax error** — every new tool follows the same pattern `callers_of_class.max_depth` does.
+- +41 new tests (parametrized shared error-path coverage across all 5 tools; happy-path + limit-validation + empty-input per tool).
+- End-to-end verified live against Twenty: every tool returned real data. `most_injected_services(5)` surfaced `TwentyConfigService` (136 injections), matching the raw Cypher we ran earlier.
+- Code-reviewer pass returned **clean** on the first round — no fixes needed.
+
+---
+
+## Repository state
+
+| Thing | Value |
+|---|---|
+| Current branch | `dev` |
+| Base branch | `main` |
+| Commits ahead of `main` | 6 (see above) |
+| Remote status | `dev` pushed to `origin/dev` ✅ |
+| PR | **not opened yet** |
+| Working tree | Clean (only `.claude/` untracked, intentional — agent config) |
+| Test count | 103 |
+| Test runtime | ~10 s |
+| Byte-compile | Clean |
+| Last `pip install -e .` | After commit `c198c5d` (MCP server). Re-run if you modify `pyproject.toml`. |
+
+---
+
+## Environment setup
+
+### Python + venv
+
+```bash
+cd codegraph
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+.venv/bin/pip install -e .
+.venv/bin/pip install "mcp>=1.0" pytest    # MCP extra + test deps
+```
+
+- System `python3` (3.12) is fine for `compileall` and `pytest` if pytest is installed globally, but **all CLI-level invocations of `codegraph` / `codegraph-mcp` must go through `.venv/bin/`** because they depend on `typer`, `neo4j`, `tree-sitter`, `rich`, and `mcp` which live in the venv.
+- There is **no system-wide `python`** (no `python` on PATH, only `python3`). Bash tool calls using `python` will fail with command-not-found. Use `python3` or `.venv/bin/python`.
+
+### Neo4j
+
+The bundled `codegraph/docker-compose.yml` runs Neo4j on:
+- Bolt: `bolt://localhost:7688`
+- Browser: `http://localhost:7475`
+- Auth: `neo4j` / `codegraph123`
+
+Start with `cd codegraph && docker compose up -d`. The container name is `codegraph-neo4j`. It's currently **up and healthy** and has the Twenty graph loaded from the last `codegraph index` run.
+
+### Twenty CRM fixture
+
+Cloned at `/tmp/twenty` this session. Shallow clone from `https://github.com/twentyhq/twenty.git`. Two packages that matter for codegraph:
+- `/tmp/twenty/packages/twenty-server` — NestJS backend (v11.1.16, yarn). 2549 classes, 110 endpoints, 428 GraphQL operations.
+- `/tmp/twenty/packages/twenty-front` — React (TypeScript) frontend. Tons of components + hooks.
+
+`/tmp/twenty` may or may not survive between sessions — `/tmp` is wiped on reboot. If missing, re-clone with `git clone --depth 1 https://github.com/twentyhq/twenty.git /tmp/twenty`.
+
+The two opt-in integration tests in `tests/test_framework.py` (`test_twenty_server_is_nestjs`, `test_twenty_front_is_react_with_high_confidence`) auto-skip if `/tmp/twenty` is missing, so they don't block CI.
+
+### agent-onboarding source repo
+
+Cloned at `/tmp/agent-onboarding` on branch `autoplay`. This is the source of the ports we did. The 6 fixture apps used by `tests/test_framework.py` live at `/tmp/agent-onboarding/tests/fixtures/{react,nextjs,vue,sveltekit,angular,odoo}-app`. If missing, re-clone from the internal GitLab: `git clone git@gitlab.leyton.fr:masri/agent-onboarding.git /tmp/agent-onboarding && cd /tmp/agent-onboarding && git checkout autoplay`.
+
+---
+
+## Running things
+
+### Reindex Twenty (from scratch — wipes the graph)
+
+```bash
+cd codegraph
+.venv/bin/codegraph index /tmp/twenty -p packages/twenty-server -p packages/twenty-front
+```
+
+Takes ~30s parse + ~65s resolve on this machine. Reports stats at the end. Default `--wipe` is on; pass `--no-wipe` if you want incremental (currently a no-op — everything re-merges over the top, no stale cleanup).
+
+### Query the graph directly
+
+```bash
+.venv/bin/codegraph query "MATCH (p:Package) RETURN p.name, p.framework, p.confidence"
+.venv/bin/codegraph query --json "MATCH (c:Class {is_controller:true}) RETURN c.name LIMIT 5"
+```
+
+### Run the MCP server standalone (for JSON-RPC smoke tests)
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | timeout 10 .venv/bin/codegraph-mcp
+```
+
+For `tools/call`, build a fresh stdin each time (FastMCP handles one init + many calls per session fine, but multi-call + tool-call + complex queries can take >10s; bump the timeout on slower machines).
+
+### Run tests
+
+```bash
+cd codegraph
+.venv/bin/python -m pytest tests/ -q          # full suite, ~10s
+.venv/bin/python -m pytest tests/test_mcp.py -v  # just mcp
+python3 -m pytest tests/ -q                    # system python works too if pytest is installed globally
+```
+
+### Wire the MCP server into Claude Code
+
+Add to `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "codegraph": {
+      "command": "/full/path/to/codegraph/.venv/bin/codegraph-mcp",
+      "type": "stdio",
+      "env": {
+        "CODEGRAPH_NEO4J_URI":  "bolt://localhost:7688",
+        "CODEGRAPH_NEO4J_USER": "neo4j",
+        "CODEGRAPH_NEO4J_PASS": "codegraph123"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Code. The 10 codegraph tools should appear in the `/mcp` menu. **Not yet verified against a live Claude Code client** — only smoke-tested via the raw JSON-RPC pipe.
+
+---
+
+## What's next (ranked)
+
+The ranking assumes the same pattern the session has been using: `plan → implement → e2e validate → review loop → push`. Each tier item has enough detail to `/plan` it without re-exploring.
+
+### Tier A — cheap, high-leverage (pick one)
+
+#### A1. MCP resources / prompts — `queries.md` as named prompt templates
+
+**What:** Expose the queries in `codegraph/queries.md` as `@mcp.prompt()` templates. An agent calls `prompts/get` with a name like `"blast_radius"` and gets back a structured prompt the LLM can use to drive the next tool call, instead of having to hand-write Cypher via `query_graph`.
+
+**Why:** Natural companion to the 10 tools we just shipped. Converts the "examples" documentation into machine-consumable templates. No schema changes, no loader changes, no new dependencies.
+
+**Scope:** ~150 LOC.
+- Parse `queries.md` → extract each `## N. Title` section + its Cypher fenced block.
+- Register each as a `@mcp.prompt(name="...", description="...")` returning a `PromptMessage` list that includes the Cypher + an explanation of what it does.
+- Alternatively: hard-code a curated subset of 5-8 prompts in `mcp.py` rather than parsing `queries.md` (more maintainable but drifts from docs).
+- Tests: monkeypatch the FastMCP prompt registry, assert the registered prompts have the expected names.
+- README: one new subsection under "Exposing the graph to Claude via MCP".
+
+**Gotchas:** FastMCP's prompt API is separate from the tool API and uses a different decorator signature. The existing test fake (`FakeDriver`) doesn't need changes; prompts don't touch Neo4j. `mcp.server.fastmcp.FastMCP.list_prompts()` is the sister to `list_tools()`.
+
+**Delivers:** Completes the "expose the graph to agents" story on the MCP side. Nothing else is missing at the retrieval layer.
+
+#### A2. GitHub Actions CI workflow
+
+**What:** `.github/workflows/test.yml` that runs pytest on push and PR.
+
+**Why:** No CI yet. Cheap (~30 LOC YAML). Worth doing before the repo sees contributors or before we open the PR for the 6 session commits.
+
+**Scope:** ~30 LOC YAML.
+- Python 3.10, 3.11, 3.12 matrix.
+- Install `requirements.txt` + `mcp` + `pytest`.
+- Run `python -m compileall -q codegraph` + `python -m pytest tests/`.
+- Skip Neo4j-requiring tests automatically (none currently require it; all are mocked).
+- The two Twenty integration tests in `test_framework.py` auto-skip because `/tmp/twenty` doesn't exist in CI — no extra guarding needed.
+
+**Gotchas:** None. This is pure infra.
+
+**Delivers:** Safety net before the PR lands.
+
+### Tier B — meaningful, moderate effort
+
+#### B1. Incremental re-indexing — `codegraph index --since HEAD~N`
+
+**What:** Diff git, re-parse only touched files, upsert into the existing graph (no wipe).
+
+**Why:** Today `codegraph index` wipes and rebuilds. For agent workflows where Claude Code edits files in a long session, you can't keep the graph current without a ~95s rebuild. Incremental closes that loop. Listed on the README roadmap as "Incremental re-indexing on file changes".
+
+**Scope:** ~400 LOC. Touches:
+- `codegraph/cli.py` — new `--since <ref>` / `--since-files <file1,file2>` flags. Mutually exclusive with the default "index everything" mode.
+- `codegraph/loader.py` — new semantics: don't wipe, delete-then-merge per file, handle orphan node cleanup for files that were deleted since the last run.
+- `codegraph/parser.py` — unchanged (parser is stateless).
+- `codegraph/resolver.py` — tricky. Cross-file resolution is a global pass. Two options:
+  - (a) Reparse only changed files + run `link_cross_file` over the full index each time (slower but safe).
+  - (b) Re-run `link_cross_file` only for edges touching changed files (faster but has cascade cases).
+  - **Recommend (a) for v1**, add (b) as a follow-up if perf is a real problem.
+- `codegraph/tests/test_incremental.py` — new file. Create a small fake repo in `tmp_path`, index it, modify one file, re-index with `--since`, assert the graph matches a full re-index of the new state.
+
+**Gotchas:**
+- **Stale edges.** If an old file had `IMPORTS` edges that no longer exist, the new parse will emit fewer edges but the old ones will still be in Neo4j. Need to delete all edges originating from `:File {path:$p}` before re-inserting.
+- **Orphan nodes.** Functions / Classes inside a now-deleted file need cleanup too. Or accept that they'll be orphaned — Cypher queries filter by `:File` membership typically, so orphans may be harmless.
+- **Git detection.** `--since HEAD~5` implies a git repo; add an error for non-git paths or fall back to "just reindex everything".
+
+**Delivers:** The final roadmap item for "make the graph stay fresh". Unlocks **Tier B2** (MCP write tools) because it provides the upsert primitive.
+
+#### B2. MCP write tools behind `--allow-write`
+
+**What:** Add `reindex_file(path)` and `wipe_graph()` tools to `codegraph-mcp`, gated by a `--allow-write` flag on the server.
+
+**Why:** Lets Claude Code refresh the graph after editing without shelling out. Currently the agent has to drop to Bash, run `codegraph index`, and wait 95s.
+
+**Scope:** ~100 LOC after B1 lands.
+- New CLI flag `codegraph-mcp --allow-write` (passed via the `args` field in `~/.claude.json` `mcpServers` block).
+- Sessions are still `READ_ACCESS` for the existing 10 tools; the new tools open a separate `WRITE_ACCESS` session.
+- `reindex_file(path)` calls the same internals as `codegraph index --since-files <path>`.
+- `wipe_graph()` requires a confirmation parameter or just a strong warning in the docstring.
+- Tests: monkeypatched driver + assert `WRITE_ACCESS` was requested for the write tools only.
+
+**Blocked by:** B1 (incremental re-indexing).
+
+#### B3. Investigate the 29% unresolved imports
+
+**What:** Twenty indexing logged `imports: total=77417 resolved=54823 unresolved=22594 (70.8% resolved)`. 22594 unresolved is a lot. Some are legit external npm packages (fine — `:External` nodes), but some fraction are definitely TS path aliases or barrel re-exports that the resolver gave up on.
+
+**Why:** Edges we're dropping on the floor reduce the value of the graph for every downstream query.
+
+**Scope:** Investigation first, then fix. Needs:
+- Dump a sample of unresolved import specifiers: `MATCH (f:File)-[r:IMPORTS_EXTERNAL]->(e:External) RETURN e.specifier, count(f) AS n ORDER BY n DESC LIMIT 50`.
+- Categorize: (a) real externals like `react`, `lodash` — keep. (b) tsconfig path aliases like `@/components/...` — resolver should have handled these. (c) barrel re-exports like `../../shared` → `shared/index.ts` — may be falling through.
+- Read `codegraph/resolver.py` to understand which step gives up and why.
+- Likely fix: beef up the alias resolution + barrel-export handling in `resolver.py`.
+
+**Needs investigation before planning.** Don't write a plan from cold.
+
+### Tier C — defer
+
+#### C1. `relationship_mapper` port (low value)
+
+`RENDERS` and `RENDERS_COMPONENT` edges are already in the schema. The only net-adds from agent-onboarding's `relationship_mapper.py` would be `NAVIGATES_TO` (route → route) and `SHARES_STATE` (components using same hooks/stores). Both are fuzzy heuristics with low confidence. Not worth it until MCP usage reveals a specific need.
+
+#### C2. Python / Go parser frontends
+
+Big tree-sitter work. Not the bottleneck. Current codebase is TypeScript-focused and that's fine.
+
+#### C3. `knowledge_enricher` LLM-powered semantic pass
+
+The biggest bet from the agent-onboarding analysis. Adds LLM-generated semantic edges (cross-file feature clustering, element → feature binding, etc.) on top of the structural graph. Worth revisiting once real-world MCP usage surfaces questions worth enriching. Defer until agents are actually asking questions the structural graph can't answer.
+
+#### C4. Rich per-query provenance in MCP responses
+
+Attaching file paths and line ranges to every returned row would help LLM grounding. Separate concern; defer until someone asks.
+
+---
+
+## Known open questions
+
+1. **Does the live Claude Code client actually show the 10 codegraph tools?** Only verified via raw JSON-RPC pipe this session. Need to add the `mcpServers` block to `~/.claude.json`, restart Claude Code, and confirm `/mcp` lists codegraph. Low risk but unverified.
+
+2. **Unresolved imports percentage** (see B3). 29% is suspicious; investigation before a fix.
+
+3. **`find_class` case sensitivity** — we kept it case-sensitive so the `class_name` index is usable. If agents consistently miss the case, we may need a `name_lower` property and a matching index. Revisit if user reports come in.
+
+4. **`gql_operation_callers` name uniqueness** — Twenty has 428 GraphQL operations. Some names may exist across query/mutation/subscription types. The `op_type` parameter narrows it, but the default (None) returns all matches. Is that the right default? For now yes — the agent can filter client-side.
+
+5. **Incremental indexing edge semantics** (see B1). Stale edge cleanup is the hardest piece. Full-delete-and-reinsert is safe but can cascade. A per-file edge TTL or versioning would be cleaner but much more work.
+
+6. **Who is the canonical maintainer of `.codegraphignore`?** The file is hand-written by users. Do we want a `codegraph ignore init` command that scaffolds a sensible default? Not shipped this session, deliberately out of scope for the ignore commit.
+
+---
+
+## Session workflow conventions (for the next agent)
+
+These have worked well and are worth continuing:
+
+1. **`/plan` before every non-trivial implementation.** Write the plan to `~/.claude/plans/<name>.md`. Include: Context (why), Critical files, Design decisions with rejected alternatives, Tests, Verification, explicit Non-goals. Get user sign-off before coding.
+
+2. **Atomic commits with detailed messages.** Every commit is scoped to one conceptual change. Commit messages are ~30-50 lines with an overview, a per-file rationale, and a verification note. See `git log --format=fuller` for the established style.
+
+3. **E2E test on Twenty after every feature.** Run `codegraph index /tmp/twenty -p packages/twenty-server -p packages/twenty-front` and check `:Package` / MCP tool responses against a real monorepo. This is how we caught the framework detector's NestJS / workspace / lockfile bugs.
+
+4. **Run `feature-dev:code-reviewer` after shipping.** Loop until clean. Round 1 usually finds 2-5 issues, round 2 usually finds 1-2, round 3 is usually clean. The scope prompt in this session's review calls was deliberately tight (per-commit) — agents get confused if you hand them the whole repo.
+
+5. **Limits in Cypher.** Neo4j 5.x **does not accept `LIMIT $param`** as a bind parameter. Validate the integer via `_validate_limit` and **interpolate** into the Cypher string. This is the same pattern `callers_of_class.max_depth` uses. Every new MCP tool with a limit should follow suit.
+
+6. **Test fakes pin the pattern.** The `_FakeDriver` / `_FakeSession` / `_FakeRecord` trio in `test_mcp.py` is how we test Neo4j-dependent code without Neo4j. It's deliberately minimal — if you find yourself extending it significantly, consider whether you're testing the wrong layer.
+
+7. **Never commit the `.claude/` directory.** It's intentionally untracked (agent config, per-session). Leave it out of `git add`.
+
+---
+
+## Plan archive — what's been written
+
+Plans live in `~/.claude/plans/`. Not in the repo. Relevant ones from this session:
+
+- `sunny-giggling-moon.md` — **this file gets overwritten each plan mode session.** Currently contains the "extend MCP tool surface with 5 retrievers" plan that shipped as `7588522`. Previously contained the ignore filter plan (b71bc45), then the MCP server plan (c198c5d), then the framework-detector fix plan (e7382f7), then this one. Each new `/plan` overwrites the previous.
+- `framework-detector-port.md` — the framework detection port plan that shipped as `9fb4d1d`. Not overwritten.
+
+**Next agent caveat:** if you're about to `/plan` something, be aware that the harness may dump its output into `sunny-giggling-moon.md` and overwrite whatever was there. Read the file before starting a plan mode session if you want to preserve the prior plan — copy it elsewhere first.
+
+---
+
+## Non-goals (keep these out of scope unless user asks)
+
+- **Make `codegraph` work on non-TypeScript codebases.** It's TS-focused by design.
+- **Web UI or dashboard.** Neo4j Browser at `:7475` is the interactive surface; everything else is Cypher + MCP.
+- **Real-time file watching.** Incremental re-index on demand is enough; no watchers.
+- **Auth / TLS / rate-limiting on MCP.** Stdio-only, trusts the local Claude Code process spawning it.
+- **Exposing internal state via `query_graph` helper methods** — the escape hatch is `query_graph(raw_cypher)` and that's by design.
+- **Database migrations between codegraph schema versions.** Users wipe and re-index when upgrading.
+- **Windows support.** Not tested; not a goal.
+- **Replacing the existing `is_controller` / `is_component` / etc. per-file flags.** They stay alongside the new `:Package` node as within-package resolution.
+- **More than 10 MCP tools in a batch.** If tool surface grows further, add tools incrementally in small batches so each gets a proper review loop.
+- **Porting more from `agent-onboarding/`.** Only the three pieces we shipped (ignore filter, framework detector, relationship-mapper-skipped) made sense. The rest (`knowledge_enricher`, `selector_extractor`, `deep_selector_agent`, `style_extractor`, `page_scanner`, `smart_explorer`) are browser/UI-specific and don't fit codegraph's value prop.
+
+---
+
+## How to continue in a fresh agent session
+
+Starter prompt template for the next agent:
+
+```
+I'm continuing work on codegraph, a Python tool that indexes TypeScript
+monorepos into Neo4j. Read ROADMAP.md at the repo root for the full
+context of what shipped in the previous session and what's next.
+
+Current working directory: /home/edouard-gouilliard/Obsidian/SecondBrain/Personal/projects/graphrag-code
+
+Before doing anything:
+1. `git status` and `git log --oneline -10` to confirm repo state.
+2. Check that .venv exists in codegraph/ — if not, rebuild per ROADMAP.md.
+3. Verify Neo4j is up: `docker ps | grep codegraph-neo4j`.
+4. Run the test suite as a smoke check: `cd codegraph && .venv/bin/python -m pytest tests/ -q`.
+
+Then pick up at the "What's next" section of ROADMAP.md. My picks for
+next step, in order: A1 (MCP prompts), A2 (CI workflow), B1 (incremental
+re-indexing). Propose one, /plan it, then implement.
+
+Do not push to origin without asking. Do not open a PR without asking.
+```
+
+---
+
+## Appendix — quick reference of what's where
+
+### Key source files (all under `codegraph/codegraph/`)
+
+| File | Purpose | LOC |
+|---|---|---|
+| `cli.py` | Typer CLI: `index`, `query`, `validate`, `wipe`, REPL | ~490 |
+| `parser.py` | tree-sitter TS/TSX walker with framework-construct detection | ~1160 |
+| `resolver.py` | Cross-file reference resolution, `link_cross_file`, `Index` aggregator | ~550 |
+| `loader.py` | Neo4j batch writer, constraints, indexes, `LoadStats` | ~830 |
+| `schema.py` | Node + edge dataclasses shared across parser → loader | ~370 |
+| `config.py` | `codegraph.toml` / `pyproject.toml` config loader | ~190 |
+| `ignore.py` | `.codegraphignore` parser + `IgnoreFilter` class | ~180 |
+| `framework.py` | Per-package framework detection (`FrameworkDetector`) | ~510 |
+| `mcp.py` | FastMCP stdio server with 10 tools | ~410 |
+| `ownership.py` | Git log → author mapping onto graph nodes | ~130 |
+| `validate.py` | Post-load sanity-check suite | ~400 |
+| `repl.py` | Interactive Cypher REPL | ~320 |
+| `utils/neo4j_json.py` | Shared `clean_row` helper used by cli + mcp | ~30 |
+
+### Tests
+
+| File | Count | Target |
+|---|---|---|
+| `tests/test_ignore.py` | 19 | `ignore.py` + `cli._strip_ignored_components` + `cli._load_ignore_filter` |
+| `tests/test_framework.py` | 23 | `framework.py` (14 existing + 9 from `fix(framework)`, including 2 opt-in Twenty tests) |
+| `tests/test_mcp.py` | 61 | `mcp.py` (20 original + 41 from the retriever batch) |
+| **Total** | **103** | |
+
+### Key decisions recorded in commit messages (not README)
+
+Grep the session's commits for these topics:
+
+- Why `.codegraphignore` not `.agentignore` → `b71bc45` body
+- Why `is_component = False` rather than deleting `FunctionNode` → `b71bc45` body
+- Why `:Package` as flat properties rather than `:Package-[:USES]->:Framework` → `9fb4d1d` plan (`framework-detector-port.md`)
+- Why NestJS indicator weights outrank React → `e7382f7` body
+- Why the `workspaces` field guard on workspace-root package.json → `e7382f7` body
+- Why the driver is lazy and not eager → `39be5c2` body
+- Why `_FakeSession.run` unconditionally pops → `39be5c2` body
+- Why `LIMIT` is interpolated not parameterised → `7588522` body and commit messages of earlier MCP tools
+
+### Git remotes
+
+```
+origin  git@github.com:cognitx-leyton/graphrag-code.git
+```
+
+Protected branches are `main`, `release`, `hotfix`. `dev` is the working branch. All PRs go into `main` via the dev → main flow.

--- a/codegraph/codegraph/cli.py
+++ b/codegraph/codegraph/cli.py
@@ -1,11 +1,22 @@
-"""codegraph CLI: index, query, validate."""
+"""codegraph CLI: REPL (default), index, validate, query, wipe.
+
+Every subcommand supports a ``--json`` flag that switches output to a
+single machine-parseable JSON document on stdout (nothing to stderr on
+success). This is the agent-native path — Claude Code and other coding
+agents should invoke codegraph with ``--json``.
+
+Running ``codegraph`` with no subcommand drops you into an interactive
+REPL with persistent session state (see :mod:`codegraph.repl`).
+"""
 from __future__ import annotations
 
+import json
 import os
 import re
+import sys
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import typer
 from neo4j import GraphDatabase
@@ -19,7 +30,11 @@ from .parser import TsParser
 from .resolver import Index, Resolver, link_cross_file, load_package_config
 from .schema import RouteNode
 
-app = typer.Typer(help="codegraph — map a TS/TSX codebase into Neo4j")
+app = typer.Typer(
+    help="codegraph — map a TS/TSX codebase into Neo4j and query it.",
+    invoke_without_command=True,
+    no_args_is_help=False,
+)
 console = Console()
 
 
@@ -30,12 +45,35 @@ DEFAULT_PASS = os.environ.get("CODEGRAPH_NEO4J_PASS", "codegraph123")
 TEST_SUFFIXES = (".spec.ts", ".spec.tsx", ".test.ts", ".test.tsx")
 
 
-# ── index ────────────────────────────────────────────────────
+# ── top-level callback: enter REPL when no subcommand ───────────────
+
+@app.callback()
+def _main(ctx: typer.Context) -> None:
+    """Drop into the REPL when ``codegraph`` is invoked without a subcommand."""
+    if ctx.invoked_subcommand is None:
+        from .repl import run_repl
+        raise typer.Exit(code=run_repl())
+
+
+# ── repl (explicit) ──────────────────────────────────────────────────
+
+@app.command()
+def repl(
+    repo: Optional[Path] = typer.Option(None, "--repo", help="Pre-set the current repo."),
+    uri: Optional[str] = typer.Option(None, "--uri", help="Pre-set the Neo4j URI."),
+    user: Optional[str] = typer.Option(None, "--user", help="Pre-set the Neo4j user."),
+) -> None:
+    """Start the interactive REPL (same as running ``codegraph`` with no args)."""
+    from .repl import run_repl
+    raise typer.Exit(code=run_repl(repo=repo, uri=uri, user=user))
+
+
+# ── index ────────────────────────────────────────────────────────────
 
 @app.command()
 def index(
     repo: Path = typer.Argument(..., exists=True, file_okay=False),
-    packages: list[str] = typer.Option(
+    packages: Optional[list[str]] = typer.Option(
         None,
         "--package", "-p",
         help="Repo-relative path of a TypeScript package to index (e.g. "
@@ -48,23 +86,58 @@ def index(
     password: str = DEFAULT_PASS,
     max_files: Optional[int] = typer.Option(None, help="Limit files (debug)"),
     skip_ownership: bool = typer.Option(False, help="Skip git log ingestion"),
+    as_json: bool = typer.Option(False, "--json", help="Emit stats as JSON on stdout."),
 ) -> None:
-    repo = repo.resolve()
-
-    # Load config (codegraph.toml, then pyproject.toml [tool.codegraph]), then
-    # overlay anything the user passed on the CLI.
+    """Index a TypeScript monorepo into Neo4j."""
     try:
-        config = load_config(repo)
-        config = merge_cli_overrides(config, packages=packages)
-        require_packages(config)
+        stats = _run_index(
+            repo=repo.resolve(),
+            packages=packages,
+            wipe=wipe,
+            uri=uri,
+            user=user,
+            password=password,
+            max_files=max_files,
+            skip_ownership=skip_ownership,
+            quiet=as_json,
+        )
     except ConfigError as e:
-        console.print(f"[bold red]Configuration error[/]\n{e}")
+        _emit_error(as_json, "config", str(e))
         raise typer.Exit(code=2)
 
+    if as_json:
+        print(json.dumps({"ok": True, "stats": stats}, indent=2))
+    else:
+        _print_load_stats_dict(stats)
+
+
+def _run_index(
+    *,
+    repo: Path,
+    packages: Optional[list[str]],
+    wipe: bool,
+    uri: str,
+    user: str,
+    password: str,
+    max_files: Optional[int] = None,
+    skip_ownership: bool = False,
+    quiet: bool = False,
+) -> dict[str, Any]:
+    """Core indexing routine. Returns a flat dict of stats (files, edges, ...).
+
+    Used by both the ``index`` command and the REPL's ``index`` handler.
+    Pass ``quiet=True`` to suppress Rich output (used by ``--json`` mode).
+    """
+    def say(msg: str) -> None:
+        if not quiet:
+            console.print(msg)
+
+    config = load_config(repo)
+    config = merge_cli_overrides(config, packages=packages)
+    require_packages(config)
+
     source_note = f" (from {config.source})" if config.source and not packages else ""
-    console.print(
-        f"[bold]Indexing[/] {repo}  packages={config.packages}{source_note}"
-    )
+    say(f"[bold]Indexing[/] {repo}  packages={config.packages}{source_note}")
 
     parser = TsParser()
     index_obj = Index()
@@ -75,20 +148,16 @@ def index(
     for pkg_path in config.packages:
         pkg_dir = (repo / pkg_path).resolve()
         if not pkg_dir.exists() or not pkg_dir.is_dir():
-            console.print(f"[yellow]skip[/] package {pkg_path} (not found at {pkg_dir})")
+            say(f"[yellow]skip[/] package {pkg_path} (not found at {pkg_dir})")
             continue
         pkg_configs.append(load_package_config(repo, pkg_dir))
-        console.print(
-            f"  [green]•[/] {pkg_path}: aliases={list(pkg_configs[-1].aliases.keys())}"
-        )
+        say(f"  [green]•[/] {pkg_path}: aliases={list(pkg_configs[-1].aliases.keys())}")
     if not pkg_configs:
-        console.print(
-            "[bold red]No valid packages found[/] — every configured package was "
-            "missing on disk. Check your codegraph.toml or --package flags."
+        raise ConfigError(
+            "No valid packages found — every configured package was missing on "
+            "disk. Check your codegraph.toml or --package flags."
         )
-        raise typer.Exit(code=2)
 
-    # Walk files (now keeping tests)
     to_parse: list[tuple[Path, str, str, bool]] = []
     for pkg in pkg_configs:
         for p in pkg.root.rglob("*"):
@@ -111,7 +180,7 @@ def index(
             to_parse.append((p, rel, pkg.name, is_test))
     if max_files is not None:
         to_parse = to_parse[:max_files]
-    console.print(f"[bold]Parsing[/] {len(to_parse)} files…")
+    say(f"[bold]Parsing[/] {len(to_parse)} files…")
 
     t0 = time.time()
     progress_step = max(1, len(to_parse) // 20)
@@ -121,57 +190,89 @@ def index(
             continue
         index_obj.add(result)
         if (i + 1) % progress_step == 0:
-            console.print(f"  parsed {i+1}/{len(to_parse)}  [{time.time()-t0:.1f}s]")
-    console.print(f"[bold green]✓[/] parsed {len(index_obj.files_by_path)} files in {time.time()-t0:.1f}s")
+            say(f"  parsed {i+1}/{len(to_parse)}  [{time.time()-t0:.1f}s]")
+    parse_time = time.time() - t0
+    say(f"[bold green]✓[/] parsed {len(index_obj.files_by_path)} files in {parse_time:.1f}s")
 
-    # Phase 8.3: route detection (regex over absolute files)
     _extract_routes(repo, index_obj)
 
-    console.print("[bold]Resolving imports + references…")
+    say("[bold]Resolving imports + references…")
     resolver = Resolver(repo, pkg_configs)
     t0 = time.time()
     all_edges = link_cross_file(index_obj, resolver)
     stats_edge = next((e for e in all_edges if e.kind == "__STATS__"), None)
+    total_imports = unresolved_imports = 0
     if stats_edge:
-        ti = stats_edge.props.get("total_imports", 0)
-        ui = stats_edge.props.get("unresolved_imports", 0)
-        pct = 100.0 * (ti - ui) / ti if ti else 0.0
-        console.print(
-            f"  imports: total={ti} resolved={ti-ui} unresolved={ui} "
-            f"({pct:.1f}% resolved)  [{time.time()-t0:.1f}s]"
+        total_imports = stats_edge.props.get("total_imports", 0)
+        unresolved_imports = stats_edge.props.get("unresolved_imports", 0)
+        pct = 100.0 * (total_imports - unresolved_imports) / total_imports if total_imports else 0.0
+        say(
+            f"  imports: total={total_imports} resolved={total_imports-unresolved_imports} "
+            f"unresolved={unresolved_imports} ({pct:.1f}% resolved)  [{time.time()-t0:.1f}s]"
         )
 
-    # Per-file edges (DECORATED_BY etc.)
     for r in index_obj.files_by_path.values():
         all_edges.extend(r.edges)
 
-    # Phase 7: ownership
     ownership = None
     if not skip_ownership:
-        console.print("[bold]Collecting git ownership…")
+        say("[bold]Collecting git ownership…")
         t0 = time.time()
         ownership = collect_ownership(repo, set(index_obj.files_by_path.keys()))
         if ownership:
-            console.print(
+            say(
                 f"  authors={len(ownership['authors'])} "
                 f"last_mod={len(ownership['last_modified'])} "
                 f"teams={len(ownership['teams'])}  [{time.time()-t0:.1f}s]"
             )
 
-    console.print("[bold]Connecting to Neo4j…", uri)
+    say(f"[bold]Connecting to Neo4j…[/] {uri}")
     loader = Neo4jLoader(uri, user, password)
     try:
         loader.init_schema()
         if wipe:
-            console.print("[yellow]Wiping database…")
+            say("[yellow]Wiping database…")
             loader.wipe()
             loader.init_schema()
         t0 = time.time()
-        ls = loader.load(index_obj, [e for e in all_edges if e.kind != "__STATS__"], ownership=ownership)
-        console.print(f"[bold green]✓[/] loaded in {time.time()-t0:.1f}s")
-        _print_load_stats(ls)
+        ls = loader.load(
+            index_obj,
+            [e for e in all_edges if e.kind != "__STATS__"],
+            ownership=ownership,
+        )
+        say(f"[bold green]✓[/] loaded in {time.time()-t0:.1f}s")
     finally:
         loader.close()
+
+    return _flatten_load_stats(ls, total_imports=total_imports, unresolved_imports=unresolved_imports)
+
+
+def _flatten_load_stats(stats, *, total_imports: int, unresolved_imports: int) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "total_imports": total_imports,
+        "unresolved_imports": unresolved_imports,
+    }
+    for k in (
+        "files", "classes", "functions", "methods", "interfaces", "endpoints",
+        "gql_operations", "columns", "atoms", "externals",
+    ):
+        out[k] = int(getattr(stats, k, 0))
+    edges = getattr(stats, "edges", {}) or {}
+    out["edges"] = {k: int(v) for k, v in edges.items()}
+    return out
+
+
+def _print_load_stats_dict(stats: dict[str, Any]) -> None:
+    t = Table(title="Load stats", show_header=True, header_style="bold magenta")
+    t.add_column("entity"); t.add_column("count", justify="right")
+    for k in (
+        "files", "classes", "functions", "methods", "interfaces", "endpoints",
+        "gql_operations", "columns", "atoms", "externals",
+    ):
+        t.add_row(k, str(stats.get(k, 0)))
+    for k, v in sorted(stats.get("edges", {}).items()):
+        t.add_row(f"edge:{k}", str(v))
+    console.print(t)
 
 
 _ROUTE_RE = re.compile(
@@ -181,11 +282,10 @@ _ROUTE_RE = re.compile(
 
 
 def _extract_routes(repo: Path, index_obj: Index) -> None:
-    """Phase 8.3: best-effort React Router <Route path="..." element={<X/>}/> detection."""
+    """Best-effort ``<Route path="…" element={<X/>}/>`` detection."""
     for rel, result in index_obj.files_by_path.items():
         if not rel.endswith(".tsx"):
             continue
-        # Cheap gate: only files mentioning Route or router are likely
         name_l = rel.lower()
         if "route" not in name_l and "router" not in name_l and "app.tsx" not in name_l:
             continue
@@ -200,7 +300,7 @@ def _extract_routes(repo: Path, index_obj: Index) -> None:
             result.routes.append(RouteNode(path=path, component_name=comp, file=rel))
 
 
-# ── validate ─────────────────────────────────────────────────
+# ── validate ─────────────────────────────────────────────────────────
 
 @app.command()
 def validate(
@@ -208,13 +308,35 @@ def validate(
     uri: str = DEFAULT_URI,
     user: str = DEFAULT_USER,
     password: str = DEFAULT_PASS,
+    as_json: bool = typer.Option(False, "--json", help="Emit report as JSON on stdout."),
 ) -> None:
+    """Run the validation suite against an already-loaded graph."""
     from .validate import run_validation
-    report = run_validation(uri, user, password, repo.resolve(), console)
+
+    report = run_validation(
+        uri, user, password, repo.resolve(),
+        console=None if as_json else console,
+    )
+    if as_json:
+        print(json.dumps({"ok": report.ok, "report": _serialize_report(report)}, indent=2))
     raise typer.Exit(code=0 if report.ok else 1)
 
 
-# ── query ────────────────────────────────────────────────────
+def _serialize_report(report) -> dict[str, Any]:
+    """Best-effort serialisation of a ValidationReport — tolerant of shape drift."""
+    out: dict[str, Any] = {"ok": bool(getattr(report, "ok", False))}
+    for attr in ("coverage", "assertions", "smoke", "errors", "warnings"):
+        val = getattr(report, attr, None)
+        if val is not None:
+            try:
+                json.dumps(val)
+                out[attr] = val
+            except TypeError:
+                out[attr] = str(val)
+    return out
+
+
+# ── query ────────────────────────────────────────────────────────────
 
 @app.command()
 def query(
@@ -222,14 +344,23 @@ def query(
     uri: str = DEFAULT_URI,
     user: str = DEFAULT_USER,
     password: str = DEFAULT_PASS,
-    limit: int = typer.Option(20),
+    limit: int = typer.Option(20, "--limit", "-n"),
+    as_json: bool = typer.Option(False, "--json", help="Emit rows as JSON on stdout."),
 ) -> None:
+    """Run a Cypher query against the current graph."""
     driver = GraphDatabase.driver(uri, auth=(user, password))
     try:
         with driver.session() as s:
             rows = list(s.run(cypher))[:limit]
     finally:
         driver.close()
+
+    if as_json:
+        serialised = [dict(r) for r in rows]
+        # neo4j Node/Relationship aren't directly JSON-serialisable, flatten them
+        clean = [_clean_row(r) for r in serialised]
+        print(json.dumps({"ok": True, "rows": clean, "count": len(clean)}, indent=2, default=str))
+        return
 
     if not rows:
         console.print("[dim](no rows)[/]")
@@ -243,31 +374,49 @@ def query(
     console.print(t)
 
 
-# ── wipe ─────────────────────────────────────────────────────
+def _clean_row(row: dict) -> dict:
+    """Best-effort JSON-clean of neo4j row values (nodes, relationships, paths)."""
+    out = {}
+    for k, v in row.items():
+        try:
+            json.dumps(v)
+            out[k] = v
+        except TypeError:
+            if hasattr(v, "_properties"):
+                out[k] = dict(v._properties)  # neo4j Node
+            else:
+                out[k] = str(v)
+    return out
+
+
+# ── wipe ─────────────────────────────────────────────────────────────
 
 @app.command()
 def wipe(
     uri: str = DEFAULT_URI,
     user: str = DEFAULT_USER,
     password: str = DEFAULT_PASS,
+    as_json: bool = typer.Option(False, "--json", help="Emit confirmation as JSON on stdout."),
 ) -> None:
+    """Drop every node and relationship in the target Neo4j database."""
     loader = Neo4jLoader(uri, user, password)
     try:
         loader.wipe()
-        console.print("[green]✓[/] wiped")
     finally:
         loader.close()
+    if as_json:
+        print(json.dumps({"ok": True, "action": "wipe", "uri": uri}, indent=2))
+    else:
+        console.print("[green]✓[/] wiped")
 
 
-def _print_load_stats(stats) -> None:
-    t = Table(title="Load stats", show_header=True, header_style="bold magenta")
-    t.add_column("entity"); t.add_column("count", justify="right")
-    for k in ("files", "classes", "functions", "methods", "interfaces", "endpoints",
-              "gql_operations", "columns", "atoms", "externals"):
-        t.add_row(k, str(getattr(stats, k, 0)))
-    for k, v in sorted(stats.edges.items()):
-        t.add_row(f"edge:{k}", str(v))
-    console.print(t)
+# ── error emission helper ────────────────────────────────────────────
+
+def _emit_error(as_json: bool, kind: str, message: str) -> None:
+    if as_json:
+        print(json.dumps({"ok": False, "error": kind, "message": message}, indent=2), file=sys.stdout)
+    else:
+        console.print(f"[bold red]{kind} error[/]\n{message}")
 
 
 if __name__ == "__main__":

--- a/codegraph/codegraph/cli.py
+++ b/codegraph/codegraph/cli.py
@@ -12,6 +12,7 @@ from neo4j import GraphDatabase
 from rich.console import Console
 from rich.table import Table
 
+from .config import ConfigError, load_config, merge_cli_overrides, require_packages
 from .loader import Neo4jLoader
 from .ownership import collect_ownership
 from .parser import TsParser
@@ -26,13 +27,6 @@ DEFAULT_URI = os.environ.get("CODEGRAPH_NEO4J_URI", "bolt://localhost:7688")
 DEFAULT_USER = os.environ.get("CODEGRAPH_NEO4J_USER", "neo4j")
 DEFAULT_PASS = os.environ.get("CODEGRAPH_NEO4J_PASS", "codegraph123")
 
-DEFAULT_EXCLUDE_DIRS = {
-    "node_modules", "dist", "build", ".next", ".turbo", "coverage",
-    ".git", "generated", "__generated__", ".cache",
-}
-DEFAULT_EXCLUDE_SUFFIXES = (
-    ".stories.tsx", ".d.ts",
-)
 TEST_SUFFIXES = (".spec.ts", ".spec.tsx", ".test.ts", ".test.tsx")
 
 
@@ -42,8 +36,11 @@ TEST_SUFFIXES = (".spec.ts", ".spec.tsx", ".test.ts", ".test.tsx")
 def index(
     repo: Path = typer.Argument(..., exists=True, file_okay=False),
     packages: list[str] = typer.Option(
-        ["twenty-server", "twenty-front"],
+        None,
         "--package", "-p",
+        help="Repo-relative path of a TypeScript package to index (e.g. "
+             "'packages/server'). Overrides codegraph.toml / pyproject.toml. "
+             "Repeatable.",
     ),
     wipe: bool = typer.Option(True, help="Wipe Neo4j database before load"),
     uri: str = DEFAULT_URI,
@@ -53,21 +50,43 @@ def index(
     skip_ownership: bool = typer.Option(False, help="Skip git log ingestion"),
 ) -> None:
     repo = repo.resolve()
-    console.print(f"[bold]Indexing[/] {repo}  packages={packages}")
+
+    # Load config (codegraph.toml, then pyproject.toml [tool.codegraph]), then
+    # overlay anything the user passed on the CLI.
+    try:
+        config = load_config(repo)
+        config = merge_cli_overrides(config, packages=packages)
+        require_packages(config)
+    except ConfigError as e:
+        console.print(f"[bold red]Configuration error[/]\n{e}")
+        raise typer.Exit(code=2)
+
+    source_note = f" (from {config.source})" if config.source and not packages else ""
+    console.print(
+        f"[bold]Indexing[/] {repo}  packages={config.packages}{source_note}"
+    )
 
     parser = TsParser()
     index_obj = Index()
+    exclude_dirs = config.effective_exclude_dirs()
+    exclude_suffixes = config.effective_exclude_suffixes()
 
     pkg_configs = []
-    for pkg_name in packages:
-        pkg_dir = repo / "packages" / pkg_name
-        if not pkg_dir.exists():
-            console.print(f"[yellow]skip[/] package {pkg_name} (not found)")
+    for pkg_path in config.packages:
+        pkg_dir = (repo / pkg_path).resolve()
+        if not pkg_dir.exists() or not pkg_dir.is_dir():
+            console.print(f"[yellow]skip[/] package {pkg_path} (not found at {pkg_dir})")
             continue
         pkg_configs.append(load_package_config(repo, pkg_dir))
         console.print(
-            f"  [green]•[/] {pkg_name}: aliases={list(pkg_configs[-1].aliases.keys())}"
+            f"  [green]•[/] {pkg_path}: aliases={list(pkg_configs[-1].aliases.keys())}"
         )
+    if not pkg_configs:
+        console.print(
+            "[bold red]No valid packages found[/] — every configured package was "
+            "missing on disk. Check your codegraph.toml or --package flags."
+        )
+        raise typer.Exit(code=2)
 
     # Walk files (now keeping tests)
     to_parse: list[tuple[Path, str, str, bool]] = []
@@ -75,12 +94,12 @@ def index(
         for p in pkg.root.rglob("*"):
             if not p.is_file():
                 continue
-            if any(part in DEFAULT_EXCLUDE_DIRS for part in p.parts):
+            if any(part in exclude_dirs for part in p.parts):
                 continue
             if p.suffix.lower() not in (".ts", ".tsx"):
                 continue
             name_lower = p.name.lower()
-            if any(name_lower.endswith(suf) for suf in DEFAULT_EXCLUDE_SUFFIXES):
+            if any(name_lower.endswith(suf) for suf in exclude_suffixes):
                 continue
             try:
                 if p.stat().st_size > 1_500_000:

--- a/codegraph/codegraph/cli.py
+++ b/codegraph/codegraph/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 import time
 from pathlib import Path
 from typing import Optional
@@ -12,8 +13,10 @@ from rich.console import Console
 from rich.table import Table
 
 from .loader import Neo4jLoader
+from .ownership import collect_ownership
 from .parser import TsParser
 from .resolver import Index, Resolver, link_cross_file, load_package_config
+from .schema import RouteNode
 
 app = typer.Typer(help="codegraph — map a TS/TSX codebase into Neo4j")
 console = Console()
@@ -28,32 +31,30 @@ DEFAULT_EXCLUDE_DIRS = {
     ".git", "generated", "__generated__", ".cache",
 }
 DEFAULT_EXCLUDE_SUFFIXES = (
-    ".spec.ts", ".spec.tsx", ".test.ts", ".test.tsx",
     ".stories.tsx", ".d.ts",
 )
+TEST_SUFFIXES = (".spec.ts", ".spec.tsx", ".test.ts", ".test.tsx")
 
 
 # ── index ────────────────────────────────────────────────────
 
 @app.command()
 def index(
-    repo: Path = typer.Argument(..., help="Repo root to index", exists=True, file_okay=False),
+    repo: Path = typer.Argument(..., exists=True, file_okay=False),
     packages: list[str] = typer.Option(
         ["twenty-server", "twenty-front"],
         "--package", "-p",
-        help="Package directory names under repo/packages/ to include",
     ),
     wipe: bool = typer.Option(True, help="Wipe Neo4j database before load"),
     uri: str = DEFAULT_URI,
     user: str = DEFAULT_USER,
     password: str = DEFAULT_PASS,
     max_files: Optional[int] = typer.Option(None, help="Limit files (debug)"),
+    skip_ownership: bool = typer.Option(False, help="Skip git log ingestion"),
 ) -> None:
-    """Parse all TS/TSX files in the selected packages and load into Neo4j."""
     repo = repo.resolve()
     console.print(f"[bold]Indexing[/] {repo}  packages={packages}")
 
-    # 1. Discover files and build per-package configs
     parser = TsParser()
     index_obj = Index()
 
@@ -68,8 +69,8 @@ def index(
             f"  [green]•[/] {pkg_name}: aliases={list(pkg_configs[-1].aliases.keys())}"
         )
 
-    # 2. Walk files
-    to_parse: list[tuple[Path, str, str]] = []
+    # Walk files (now keeping tests)
+    to_parse: list[tuple[Path, str, str, bool]] = []
     for pkg in pkg_configs:
         for p in pkg.root.rglob("*"):
             if not p.is_file():
@@ -86,17 +87,17 @@ def index(
                     continue
             except OSError:
                 continue
+            is_test = any(name_lower.endswith(suf) for suf in TEST_SUFFIXES)
             rel = str(p.resolve().relative_to(repo)).replace("\\", "/")
-            to_parse.append((p, rel, pkg.name))
+            to_parse.append((p, rel, pkg.name, is_test))
     if max_files is not None:
         to_parse = to_parse[:max_files]
     console.print(f"[bold]Parsing[/] {len(to_parse)} files…")
 
-    # 3. Parse
     t0 = time.time()
     progress_step = max(1, len(to_parse) // 20)
-    for i, (abs_p, rel, pkg_name) in enumerate(to_parse):
-        result = parser.parse_file(abs_p, rel, pkg_name)
+    for i, (abs_p, rel, pkg_name, is_test) in enumerate(to_parse):
+        result = parser.parse_file(abs_p, rel, pkg_name, is_test=is_test)
         if result is None:
             continue
         index_obj.add(result)
@@ -104,26 +105,41 @@ def index(
             console.print(f"  parsed {i+1}/{len(to_parse)}  [{time.time()-t0:.1f}s]")
     console.print(f"[bold green]✓[/] parsed {len(index_obj.files_by_path)} files in {time.time()-t0:.1f}s")
 
-    # 4. Resolve cross-file references
+    # Phase 8.3: route detection (regex over absolute files)
+    _extract_routes(repo, index_obj)
+
     console.print("[bold]Resolving imports + references…")
     resolver = Resolver(repo, pkg_configs)
     t0 = time.time()
     all_edges = link_cross_file(index_obj, resolver)
-    # Also include edges emitted directly during parsing (DECORATED_BY etc.)
-    for r in index_obj.files_by_path.values():
-        all_edges.extend(r.edges)
-    stats = next((e for e in all_edges if e.kind == "__STATS__"), None)
-    if stats:
-        ti = stats.props.get("total_imports", 0)
-        ui = stats.props.get("unresolved_imports", 0)
+    stats_edge = next((e for e in all_edges if e.kind == "__STATS__"), None)
+    if stats_edge:
+        ti = stats_edge.props.get("total_imports", 0)
+        ui = stats_edge.props.get("unresolved_imports", 0)
         pct = 100.0 * (ti - ui) / ti if ti else 0.0
         console.print(
             f"  imports: total={ti} resolved={ti-ui} unresolved={ui} "
             f"({pct:.1f}% resolved)  [{time.time()-t0:.1f}s]"
         )
 
-    # 5. Neo4j load
-    console.print("[bold]Connecting to Neo4j…", DEFAULT_URI if uri is DEFAULT_URI else uri)
+    # Per-file edges (DECORATED_BY etc.)
+    for r in index_obj.files_by_path.values():
+        all_edges.extend(r.edges)
+
+    # Phase 7: ownership
+    ownership = None
+    if not skip_ownership:
+        console.print("[bold]Collecting git ownership…")
+        t0 = time.time()
+        ownership = collect_ownership(repo, set(index_obj.files_by_path.keys()))
+        if ownership:
+            console.print(
+                f"  authors={len(ownership['authors'])} "
+                f"last_mod={len(ownership['last_modified'])} "
+                f"teams={len(ownership['teams'])}  [{time.time()-t0:.1f}s]"
+            )
+
+    console.print("[bold]Connecting to Neo4j…", uri)
     loader = Neo4jLoader(uri, user, password)
     try:
         loader.init_schema()
@@ -132,33 +148,48 @@ def index(
             loader.wipe()
             loader.init_schema()
         t0 = time.time()
-        ls = loader.load(index_obj, [e for e in all_edges if e.kind != "__STATS__"])
+        ls = loader.load(index_obj, [e for e in all_edges if e.kind != "__STATS__"], ownership=ownership)
         console.print(f"[bold green]✓[/] loaded in {time.time()-t0:.1f}s")
         _print_load_stats(ls)
     finally:
         loader.close()
 
 
-def _print_load_stats(stats) -> None:
-    t = Table(title="Load stats", show_header=True, header_style="bold magenta")
-    t.add_column("entity"); t.add_column("count", justify="right")
-    for k in ("files", "classes", "functions", "interfaces", "endpoints", "externals"):
-        t.add_row(k, str(getattr(stats, k)))
-    for k, v in sorted(stats.edges.items()):
-        t.add_row(f"edge:{k}", str(v))
-    console.print(t)
+_ROUTE_RE = re.compile(
+    r"<\s*Route\b[^>]*\bpath\s*=\s*[\"']([^\"']+)[\"'][^>]*\belement\s*=\s*\{\s*<\s*([A-Z]\w*)",
+    re.MULTILINE,
+)
+
+
+def _extract_routes(repo: Path, index_obj: Index) -> None:
+    """Phase 8.3: best-effort React Router <Route path="..." element={<X/>}/> detection."""
+    for rel, result in index_obj.files_by_path.items():
+        if not rel.endswith(".tsx"):
+            continue
+        # Cheap gate: only files mentioning Route or router are likely
+        name_l = rel.lower()
+        if "route" not in name_l and "router" not in name_l and "app.tsx" not in name_l:
+            continue
+        try:
+            text = (repo / rel).read_text(errors="replace")
+        except OSError:
+            continue
+        if "<Route" not in text:
+            continue
+        for m in _ROUTE_RE.finditer(text):
+            path, comp = m.group(1), m.group(2)
+            result.routes.append(RouteNode(path=path, component_name=comp, file=rel))
 
 
 # ── validate ─────────────────────────────────────────────────
 
 @app.command()
 def validate(
-    repo: Path = typer.Argument(..., help="Repo root (for grep-based ground truth)", exists=True, file_okay=False),
+    repo: Path = typer.Argument(..., exists=True, file_okay=False),
     uri: str = DEFAULT_URI,
     user: str = DEFAULT_USER,
     password: str = DEFAULT_PASS,
 ) -> None:
-    """Run coverage metrics + ground-truth assertions + smoke queries."""
     from .validate import run_validation
     report = run_validation(uri, user, password, repo.resolve(), console)
     raise typer.Exit(code=0 if report.ok else 1)
@@ -168,13 +199,12 @@ def validate(
 
 @app.command()
 def query(
-    cypher: str = typer.Argument(..., help="A Cypher query"),
+    cypher: str = typer.Argument(...),
     uri: str = DEFAULT_URI,
     user: str = DEFAULT_USER,
     password: str = DEFAULT_PASS,
-    limit: int = typer.Option(20, help="Row limit"),
+    limit: int = typer.Option(20),
 ) -> None:
-    """Run an ad-hoc Cypher query and print results as a table."""
     driver = GraphDatabase.driver(uri, auth=(user, password))
     try:
         with driver.session() as s:
@@ -202,13 +232,23 @@ def wipe(
     user: str = DEFAULT_USER,
     password: str = DEFAULT_PASS,
 ) -> None:
-    """Drop all nodes and edges from the Neo4j database."""
     loader = Neo4jLoader(uri, user, password)
     try:
         loader.wipe()
         console.print("[green]✓[/] wiped")
     finally:
         loader.close()
+
+
+def _print_load_stats(stats) -> None:
+    t = Table(title="Load stats", show_header=True, header_style="bold magenta")
+    t.add_column("entity"); t.add_column("count", justify="right")
+    for k in ("files", "classes", "functions", "methods", "interfaces", "endpoints",
+              "gql_operations", "columns", "atoms", "externals"):
+        t.add_row(k, str(getattr(stats, k, 0)))
+    for k, v in sorted(stats.edges.items()):
+        t.add_row(f"edge:{k}", str(v))
+    console.print(t)
 
 
 if __name__ == "__main__":

--- a/codegraph/codegraph/cli.py
+++ b/codegraph/codegraph/cli.py
@@ -24,6 +24,7 @@ from rich.console import Console
 from rich.table import Table
 
 from .config import ConfigError, load_config, merge_cli_overrides, require_packages
+from .ignore import IgnoreConfigError, IgnoreFilter
 from .loader import Neo4jLoader
 from .ownership import collect_ownership
 from .parser import TsParser
@@ -86,6 +87,13 @@ def index(
     password: str = DEFAULT_PASS,
     max_files: Optional[int] = typer.Option(None, help="Limit files (debug)"),
     skip_ownership: bool = typer.Option(False, help="Skip git log ingestion"),
+    ignore_file: Optional[str] = typer.Option(
+        None,
+        "--ignore-file",
+        help="Path to a .codegraphignore file (gitignore-style, plus @route: "
+             "and @component: extensions). Overrides codegraph.toml. If unset, "
+             "codegraph auto-detects <repo>/.codegraphignore.",
+    ),
     as_json: bool = typer.Option(False, "--json", help="Emit stats as JSON on stdout."),
 ) -> None:
     """Index a TypeScript monorepo into Neo4j."""
@@ -99,10 +107,14 @@ def index(
             password=password,
             max_files=max_files,
             skip_ownership=skip_ownership,
+            ignore_file=ignore_file,
             quiet=as_json,
         )
     except ConfigError as e:
         _emit_error(as_json, "config", str(e))
+        raise typer.Exit(code=2)
+    except IgnoreConfigError as e:
+        _emit_error(as_json, "ignore", str(e))
         raise typer.Exit(code=2)
 
     if as_json:
@@ -121,6 +133,7 @@ def _run_index(
     password: str,
     max_files: Optional[int] = None,
     skip_ownership: bool = False,
+    ignore_file: Optional[str] = None,
     quiet: bool = False,
 ) -> dict[str, Any]:
     """Core indexing routine. Returns a flat dict of stats (files, edges, ...).
@@ -133,11 +146,19 @@ def _run_index(
             console.print(msg)
 
     config = load_config(repo)
-    config = merge_cli_overrides(config, packages=packages)
+    config = merge_cli_overrides(config, packages=packages, ignore_file=ignore_file)
     require_packages(config)
 
     source_note = f" (from {config.source})" if config.source and not packages else ""
     say(f"[bold]Indexing[/] {repo}  packages={config.packages}{source_note}")
+
+    ignore_filter = _load_ignore_filter(repo, config.ignore_file)
+    if ignore_filter is not None:
+        nf, nr, nc = ignore_filter.counts()
+        say(
+            f"[bold]Ignore rules[/] loaded from {ignore_filter.ignore_path.name} "
+            f"({nf} file / {nr} route / {nc} component)"
+        )
 
     parser = TsParser()
     index_obj = Index()
@@ -177,6 +198,8 @@ def _run_index(
                 continue
             is_test = any(name_lower.endswith(suf) for suf in TEST_SUFFIXES)
             rel = str(p.resolve().relative_to(repo)).replace("\\", "/")
+            if ignore_filter is not None and ignore_filter.should_ignore_file(rel):
+                continue
             to_parse.append((p, rel, pkg.name, is_test))
     if max_files is not None:
         to_parse = to_parse[:max_files]
@@ -194,7 +217,12 @@ def _run_index(
     parse_time = time.time() - t0
     say(f"[bold green]✓[/] parsed {len(index_obj.files_by_path)} files in {parse_time:.1f}s")
 
-    _extract_routes(repo, index_obj)
+    _extract_routes(repo, index_obj, ignore_filter)
+
+    if ignore_filter is not None:
+        dropped = _strip_ignored_components(index_obj, ignore_filter)
+        if dropped:
+            say(f"[bold]Ignore rules[/] stripped :Component label from {dropped} function(s)")
 
     say("[bold]Resolving imports + references…")
     resolver = Resolver(repo, pkg_configs)
@@ -281,7 +309,11 @@ _ROUTE_RE = re.compile(
 )
 
 
-def _extract_routes(repo: Path, index_obj: Index) -> None:
+def _extract_routes(
+    repo: Path,
+    index_obj: Index,
+    ignore_filter: Optional[IgnoreFilter] = None,
+) -> None:
     """Best-effort ``<Route path="…" element={<X/>}/>`` detection."""
     for rel, result in index_obj.files_by_path.items():
         if not rel.endswith(".tsx"):
@@ -297,7 +329,48 @@ def _extract_routes(repo: Path, index_obj: Index) -> None:
             continue
         for m in _ROUTE_RE.finditer(text):
             path, comp = m.group(1), m.group(2)
+            if ignore_filter is not None and ignore_filter.should_ignore_route(path):
+                continue
             result.routes.append(RouteNode(path=path, component_name=comp, file=rel))
+
+
+def _strip_ignored_components(index_obj: Index, ignore_filter: IgnoreFilter) -> int:
+    """Flip ``is_component`` off for components whose name matches an ignore rule.
+
+    Flipping the flag rather than deleting the :class:`FunctionNode` is
+    deliberate: the function may still be legitimately imported or called
+    elsewhere. :mod:`codegraph.loader` only applies the ``:Component`` label
+    when ``is_component=True``, so this is all that's needed to keep the
+    component out of the queryable graph.
+    """
+    dropped = 0
+    for result in index_obj.files_by_path.values():
+        for fn in result.functions:
+            if fn.is_component and ignore_filter.should_ignore_component(fn.name):
+                fn.is_component = False
+                dropped += 1
+    return dropped
+
+
+def _load_ignore_filter(repo: Path, configured: Optional[str]) -> Optional[IgnoreFilter]:
+    """Resolve and load a :class:`IgnoreFilter`.
+
+    Resolution order:
+
+    1. If ``configured`` is set (from ``--ignore-file`` or ``codegraph.toml``),
+       use it as-is (absolute or repo-relative). Missing file is a hard error.
+    2. Otherwise, auto-detect ``<repo>/.codegraphignore``. Missing file → no
+       filter, no error.
+    """
+    if configured:
+        candidate = Path(configured)
+        if not candidate.is_absolute():
+            candidate = repo / candidate
+        return IgnoreFilter(candidate)
+    default = repo / ".codegraphignore"
+    if default.exists():
+        return IgnoreFilter(default)
+    return None
 
 
 # ── validate ─────────────────────────────────────────────────────────

--- a/codegraph/codegraph/cli.py
+++ b/codegraph/codegraph/cli.py
@@ -31,6 +31,7 @@ from .ownership import collect_ownership
 from .parser import TsParser
 from .resolver import Index, Resolver, link_cross_file, load_package_config
 from .schema import PackageNode, RouteNode
+from .utils.neo4j_json import clean_row
 
 app = typer.Typer(
     help="codegraph — map a TS/TSX codebase into Neo4j and query it.",
@@ -442,7 +443,7 @@ def query(
     if as_json:
         serialised = [dict(r) for r in rows]
         # neo4j Node/Relationship aren't directly JSON-serialisable, flatten them
-        clean = [_clean_row(r) for r in serialised]
+        clean = [clean_row(r) for r in serialised]
         print(json.dumps({"ok": True, "rows": clean, "count": len(clean)}, indent=2, default=str))
         return
 
@@ -456,21 +457,6 @@ def query(
     for r in rows:
         t.add_row(*[str(r.get(h, "")) for h in headers])
     console.print(t)
-
-
-def _clean_row(row: dict) -> dict:
-    """Best-effort JSON-clean of neo4j row values (nodes, relationships, paths)."""
-    out = {}
-    for k, v in row.items():
-        try:
-            json.dumps(v)
-            out[k] = v
-        except TypeError:
-            if hasattr(v, "_properties"):
-                out[k] = dict(v._properties)  # neo4j Node
-            else:
-                out[k] = str(v)
-    return out
 
 
 # ── wipe ─────────────────────────────────────────────────────────────

--- a/codegraph/codegraph/cli.py
+++ b/codegraph/codegraph/cli.py
@@ -24,12 +24,13 @@ from rich.console import Console
 from rich.table import Table
 
 from .config import ConfigError, load_config, merge_cli_overrides, require_packages
+from .framework import FrameworkDetector
 from .ignore import IgnoreConfigError, IgnoreFilter
 from .loader import Neo4jLoader
 from .ownership import collect_ownership
 from .parser import TsParser
 from .resolver import Index, Resolver, link_cross_file, load_package_config
-from .schema import RouteNode
+from .schema import PackageNode, RouteNode
 
 app = typer.Typer(
     help="codegraph — map a TS/TSX codebase into Neo4j and query it.",
@@ -173,6 +174,16 @@ def _run_index(
             continue
         pkg_configs.append(load_package_config(repo, pkg_dir))
         say(f"  [green]•[/] {pkg_path}: aliases={list(pkg_configs[-1].aliases.keys())}")
+
+        info = FrameworkDetector(pkg_dir).detect()
+        pkg_node = PackageNode.from_framework_info(pkg_configs[-1].name, info)
+        index_obj.packages.append(pkg_node)
+        version_str = f" v{info.version}" if info.version else ""
+        say(
+            f"    [cyan]framework[/] {pkg_node.framework}{version_str} "
+            f"(conf {info.confidence:.0%}, ts={info.typescript}, "
+            f"pm={info.package_manager or '?'})"
+        )
     if not pkg_configs:
         raise ConfigError(
             "No valid packages found — every configured package was missing on "

--- a/codegraph/codegraph/cli.py
+++ b/codegraph/codegraph/cli.py
@@ -29,7 +29,13 @@ from .ignore import IgnoreConfigError, IgnoreFilter
 from .loader import Neo4jLoader
 from .ownership import collect_ownership
 from .parser import TsParser
-from .resolver import Index, Resolver, link_cross_file, load_package_config
+from .resolver import (
+    Index,
+    Resolver,
+    link_cross_file,
+    load_package_config,
+    load_python_package_config,
+)
 from .schema import PackageNode, RouteNode
 from .utils.neo4j_json import clean_row
 
@@ -46,6 +52,14 @@ DEFAULT_USER = os.environ.get("CODEGRAPH_NEO4J_USER", "neo4j")
 DEFAULT_PASS = os.environ.get("CODEGRAPH_NEO4J_PASS", "codegraph123")
 
 TEST_SUFFIXES = (".spec.ts", ".spec.tsx", ".test.ts", ".test.tsx")
+PY_TEST_SUFFIXES = ("_test.py",)
+
+
+def _is_python_test_file(name_lower: str) -> bool:
+    """Return True for conventional pytest file names (``test_*.py`` / ``*_test.py``)."""
+    return name_lower.startswith("test_") or any(
+        name_lower.endswith(s) for s in PY_TEST_SUFFIXES
+    )
 
 
 # ── top-level callback: enter REPL when no subcommand ───────────────
@@ -162,7 +176,8 @@ def _run_index(
             f"({nf} file / {nr} route / {nc} component)"
         )
 
-    parser = TsParser()
+    ts_parser = TsParser()
+    py_parser = None  # Lazy — only constructed if a Python package is configured.
     index_obj = Index()
     exclude_dirs = config.effective_exclude_dirs()
     exclude_suffixes = config.effective_exclude_suffixes()
@@ -173,18 +188,35 @@ def _run_index(
         if not pkg_dir.exists() or not pkg_dir.is_dir():
             say(f"[yellow]skip[/] package {pkg_path} (not found at {pkg_dir})")
             continue
-        pkg_configs.append(load_package_config(repo, pkg_dir))
-        say(f"  [green]•[/] {pkg_path}: aliases={list(pkg_configs[-1].aliases.keys())}")
 
-        info = FrameworkDetector(pkg_dir).detect()
-        pkg_node = PackageNode.from_framework_info(pkg_configs[-1].name, info)
-        index_obj.packages.append(pkg_node)
-        version_str = f" v{info.version}" if info.version else ""
-        say(
-            f"    [cyan]framework[/] {pkg_node.framework}{version_str} "
-            f"(conf {info.confidence:.0%}, ts={info.typescript}, "
-            f"pm={info.package_manager or '?'})"
-        )
+        # Auto-detect language: a directory with __init__.py is Python, else TS.
+        if (pkg_dir / "__init__.py").exists():
+            pkg_config = load_python_package_config(repo, pkg_dir)
+        else:
+            pkg_config = load_package_config(repo, pkg_dir)
+        pkg_configs.append(pkg_config)
+
+        lang_label = pkg_config.language
+        say(f"  [green]•[/] {pkg_path} ({lang_label}): aliases={list(pkg_config.aliases.keys())}")
+
+        if pkg_config.language == "ts":
+            info = FrameworkDetector(pkg_dir).detect()
+            pkg_node = PackageNode.from_framework_info(pkg_config.name, info)
+            index_obj.packages.append(pkg_node)
+            version_str = f" v{info.version}" if info.version else ""
+            say(
+                f"    [cyan]framework[/] {pkg_node.framework}{version_str} "
+                f"(conf {info.confidence:.0%}, ts={info.typescript}, "
+                f"pm={info.package_manager or '?'})"
+            )
+        else:
+            # Python: Stage 1 skips framework detection. Emit a placeholder
+            # :Package node so the BELONGS_TO edges still wire up in the graph.
+            pkg_node = PackageNode(
+                name=pkg_config.name, framework="Unknown", confidence=0.0,
+            )
+            index_obj.packages.append(pkg_node)
+            say(f"    [cyan]framework[/] Unknown (python; detection in Stage 2)")
     if not pkg_configs:
         raise ConfigError(
             "No valid packages found — every configured package was missing on "
@@ -193,12 +225,16 @@ def _run_index(
 
     to_parse: list[tuple[Path, str, str, bool]] = []
     for pkg in pkg_configs:
+        # Restrict accepted extensions to the package's language. A TS
+        # package walking a .py script (or vice versa) would be a misconfig;
+        # we skip silently rather than try to parse it with the wrong frontend.
+        allowed_suffixes = (".py",) if pkg.language == "py" else (".ts", ".tsx")
         for p in pkg.root.rglob("*"):
             if not p.is_file():
                 continue
             if any(part in exclude_dirs for part in p.parts):
                 continue
-            if p.suffix.lower() not in (".ts", ".tsx"):
+            if p.suffix.lower() not in allowed_suffixes:
                 continue
             name_lower = p.name.lower()
             if any(name_lower.endswith(suf) for suf in exclude_suffixes):
@@ -208,7 +244,10 @@ def _run_index(
                     continue
             except OSError:
                 continue
-            is_test = any(name_lower.endswith(suf) for suf in TEST_SUFFIXES)
+            if pkg.language == "py":
+                is_test = _is_python_test_file(name_lower)
+            else:
+                is_test = any(name_lower.endswith(suf) for suf in TEST_SUFFIXES)
             rel = str(p.resolve().relative_to(repo)).replace("\\", "/")
             if ignore_filter is not None and ignore_filter.should_ignore_file(rel):
                 continue
@@ -220,7 +259,13 @@ def _run_index(
     t0 = time.time()
     progress_step = max(1, len(to_parse) // 20)
     for i, (abs_p, rel, pkg_name, is_test) in enumerate(to_parse):
-        result = parser.parse_file(abs_p, rel, pkg_name, is_test=is_test)
+        if abs_p.suffix.lower() == ".py":
+            if py_parser is None:
+                from .py_parser import PyParser
+                py_parser = PyParser()
+            result = py_parser.parse_file(abs_p, rel, pkg_name, is_test=is_test)
+        else:
+            result = ts_parser.parse_file(abs_p, rel, pkg_name, is_test=is_test)
         if result is None:
             continue
         index_obj.add(result)

--- a/codegraph/codegraph/cli.py
+++ b/codegraph/codegraph/cli.py
@@ -36,7 +36,13 @@ from .resolver import (
     load_package_config,
     load_python_package_config,
 )
-from .schema import PackageNode, RouteNode
+from .schema import (
+    PackageNode,
+    PY_TEST_PREFIX,
+    PY_TEST_SUFFIX_TRAILING,
+    RouteNode,
+    TS_TEST_SUFFIXES,
+)
 from .utils.neo4j_json import clean_row
 
 app = typer.Typer(
@@ -51,15 +57,9 @@ DEFAULT_URI = os.environ.get("CODEGRAPH_NEO4J_URI", "bolt://localhost:7688")
 DEFAULT_USER = os.environ.get("CODEGRAPH_NEO4J_USER", "neo4j")
 DEFAULT_PASS = os.environ.get("CODEGRAPH_NEO4J_PASS", "codegraph123")
 
-TEST_SUFFIXES = (".spec.ts", ".spec.tsx", ".test.ts", ".test.tsx")
-PY_TEST_SUFFIXES = ("_test.py",)
-
-
 def _is_python_test_file(name_lower: str) -> bool:
     """Return True for conventional pytest file names (``test_*.py`` / ``*_test.py``)."""
-    return name_lower.startswith("test_") or any(
-        name_lower.endswith(s) for s in PY_TEST_SUFFIXES
-    )
+    return name_lower.startswith(PY_TEST_PREFIX) or name_lower.endswith(PY_TEST_SUFFIX_TRAILING)
 
 
 # ── top-level callback: enter REPL when no subcommand ───────────────
@@ -247,7 +247,7 @@ def _run_index(
             if pkg.language == "py":
                 is_test = _is_python_test_file(name_lower)
             else:
-                is_test = any(name_lower.endswith(suf) for suf in TEST_SUFFIXES)
+                is_test = any(name_lower.endswith(suf) for suf in TS_TEST_SUFFIXES)
             rel = str(p.resolve().relative_to(repo)).replace("\\", "/")
             if ignore_filter is not None and ignore_filter.should_ignore_file(rel):
                 continue

--- a/codegraph/codegraph/config.py
+++ b/codegraph/codegraph/config.py
@@ -1,0 +1,175 @@
+"""codegraph configuration loader.
+
+Looks for project-level configuration in this order and merges the first match:
+
+1. ``codegraph.toml`` at the repo root — dedicated file, top-level keys.
+2. ``pyproject.toml`` at the repo root — under ``[tool.codegraph]``.
+
+The CLI accepts the same keys as flags and **flags always win** over config-file
+values. If neither file exists and no ``--package`` flag is given, indexing
+stops with a clear error — there are no hardcoded defaults.
+
+Schema::
+
+    packages = ["packages/server", "packages/web"]   # required
+    exclude_dirs = ["custom-build"]                  # extends defaults
+    exclude_suffixes = [".gen.ts"]                   # extends defaults
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Optional
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+# Hardcoded base sets — intentionally generic, not Twenty-specific.
+# Users extend these via `exclude_dirs` / `exclude_suffixes` in their config.
+BASE_EXCLUDE_DIRS: frozenset[str] = frozenset({
+    "node_modules", "dist", "build", ".next", ".turbo", "coverage",
+    ".git", "generated", "__generated__", ".cache", ".svelte-kit",
+    ".nuxt", ".output", ".parcel-cache", ".vercel",
+})
+
+BASE_EXCLUDE_SUFFIXES: tuple[str, ...] = (
+    ".stories.tsx", ".stories.ts", ".d.ts",
+)
+
+
+@dataclass
+class CodegraphConfig:
+    """Resolved configuration for an indexing run."""
+
+    packages: list[str] = field(default_factory=list)
+    """Repo-relative paths to TypeScript packages to index.
+
+    Each entry is a directory (e.g. ``"packages/server"``, ``"apps/web"``).
+    The directory should contain a ``package.json`` / ``tsconfig.json`` so
+    TypeScript path aliases can be resolved.
+    """
+
+    exclude_dirs: set[str] = field(default_factory=set)
+    """Directory names to skip during the file walk, **in addition** to
+    :data:`BASE_EXCLUDE_DIRS`. Matched against any path component."""
+
+    exclude_suffixes: tuple[str, ...] = field(default_factory=tuple)
+    """Filename suffixes to skip, **in addition** to
+    :data:`BASE_EXCLUDE_SUFFIXES`."""
+
+    source: Optional[str] = None
+    """Where the config came from (``"codegraph.toml"``,
+    ``"pyproject.toml"``, or ``None`` for CLI-only)."""
+
+    def effective_exclude_dirs(self) -> set[str]:
+        return set(BASE_EXCLUDE_DIRS) | set(self.exclude_dirs)
+
+    def effective_exclude_suffixes(self) -> tuple[str, ...]:
+        return BASE_EXCLUDE_SUFFIXES + tuple(self.exclude_suffixes)
+
+
+class ConfigError(Exception):
+    """Raised when the configuration is invalid or missing required keys."""
+
+
+def load_config(repo: Path) -> CodegraphConfig:
+    """Load configuration from the repo root.
+
+    Returns an empty :class:`CodegraphConfig` if no config file is found —
+    this is not an error on its own; the caller decides whether ``packages``
+    is required (it is, for ``index``; not for ``query`` / ``validate``).
+    """
+    repo = repo.resolve()
+
+    # 1. codegraph.toml takes precedence
+    dedicated = repo / "codegraph.toml"
+    if dedicated.exists():
+        data = _read_toml(dedicated)
+        return _build_config(data, source="codegraph.toml")
+
+    # 2. pyproject.toml [tool.codegraph]
+    pyproject = repo / "pyproject.toml"
+    if pyproject.exists():
+        data = _read_toml(pyproject).get("tool", {}).get("codegraph", {})
+        if data:
+            return _build_config(data, source="pyproject.toml")
+
+    return CodegraphConfig()
+
+
+def merge_cli_overrides(
+    config: CodegraphConfig,
+    *,
+    packages: Optional[Iterable[str]] = None,
+    exclude_dirs: Optional[Iterable[str]] = None,
+    exclude_suffixes: Optional[Iterable[str]] = None,
+) -> CodegraphConfig:
+    """Return a new config with CLI-provided values taking precedence.
+
+    ``None`` means "not provided"; an empty list means "explicitly empty"
+    (which is currently treated the same as None for ``packages`` — an empty
+    packages list is never what you want).
+    """
+    merged = CodegraphConfig(
+        packages=list(config.packages),
+        exclude_dirs=set(config.exclude_dirs),
+        exclude_suffixes=tuple(config.exclude_suffixes),
+        source=config.source,
+    )
+    if packages:
+        merged.packages = list(packages)
+    if exclude_dirs:
+        merged.exclude_dirs = set(exclude_dirs)
+    if exclude_suffixes:
+        merged.exclude_suffixes = tuple(exclude_suffixes)
+    return merged
+
+
+def require_packages(config: CodegraphConfig) -> None:
+    """Raise :class:`ConfigError` if ``packages`` is empty, with a helpful
+    message pointing the user at the config options."""
+    if config.packages:
+        return
+    raise ConfigError(
+        "No packages to index.\n\n"
+        "Specify packages in one of three ways:\n"
+        "  1. Create a codegraph.toml at the repo root:\n"
+        "       packages = [\"packages/server\", \"packages/web\"]\n"
+        "  2. Add a [tool.codegraph] section to pyproject.toml:\n"
+        "       [tool.codegraph]\n"
+        "       packages = [\"packages/server\", \"packages/web\"]\n"
+        "  3. Pass --package / -p on the command line:\n"
+        "       codegraph repo index <path> -p packages/server -p packages/web\n"
+    )
+
+
+def _read_toml(path: Path) -> dict:
+    try:
+        with path.open("rb") as f:
+            return tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ConfigError(f"Invalid TOML in {path}: {e}") from e
+
+
+def _build_config(data: dict, *, source: str) -> CodegraphConfig:
+    packages = data.get("packages", [])
+    if not isinstance(packages, list) or not all(isinstance(p, str) for p in packages):
+        raise ConfigError(
+            f"{source}: `packages` must be a list of strings (got {type(packages).__name__})"
+        )
+    exclude_dirs = data.get("exclude_dirs", [])
+    if not isinstance(exclude_dirs, list) or not all(isinstance(p, str) for p in exclude_dirs):
+        raise ConfigError(f"{source}: `exclude_dirs` must be a list of strings")
+    exclude_suffixes = data.get("exclude_suffixes", [])
+    if not isinstance(exclude_suffixes, list) or not all(isinstance(p, str) for p in exclude_suffixes):
+        raise ConfigError(f"{source}: `exclude_suffixes` must be a list of strings")
+    return CodegraphConfig(
+        packages=list(packages),
+        exclude_dirs=set(exclude_dirs),
+        exclude_suffixes=tuple(exclude_suffixes),
+        source=source,
+    )

--- a/codegraph/codegraph/config.py
+++ b/codegraph/codegraph/config.py
@@ -31,13 +31,18 @@ except ModuleNotFoundError:  # pragma: no cover
 # Hardcoded base sets — intentionally generic, not Twenty-specific.
 # Users extend these via `exclude_dirs` / `exclude_suffixes` in their config.
 BASE_EXCLUDE_DIRS: frozenset[str] = frozenset({
+    # JavaScript / TypeScript build + cache
     "node_modules", "dist", "build", ".next", ".turbo", "coverage",
     ".git", "generated", "__generated__", ".cache", ".svelte-kit",
     ".nuxt", ".output", ".parcel-cache", ".vercel",
+    # Python build + cache (used by the Python frontend from Stage 1 on)
+    "__pycache__", ".venv", "venv", ".pytest_cache", ".mypy_cache",
+    ".ruff_cache", ".tox", ".eggs", ".ipynb_checkpoints",
 })
 
 BASE_EXCLUDE_SUFFIXES: tuple[str, ...] = (
     ".stories.tsx", ".stories.ts", ".d.ts",
+    ".pyc", ".pyo",
 )
 
 

--- a/codegraph/codegraph/config.py
+++ b/codegraph/codegraph/config.py
@@ -61,6 +61,11 @@ class CodegraphConfig:
     """Filename suffixes to skip, **in addition** to
     :data:`BASE_EXCLUDE_SUFFIXES`."""
 
+    ignore_file: Optional[str] = None
+    """Repo-relative path to a ``.codegraphignore``-style file. ``None`` means
+    auto-detect ``<repo>/.codegraphignore`` at load time; if that file doesn't
+    exist either, no ignore filtering is applied. See :mod:`codegraph.ignore`."""
+
     source: Optional[str] = None
     """Where the config came from (``"codegraph.toml"``,
     ``"pyproject.toml"``, or ``None`` for CLI-only)."""
@@ -107,6 +112,7 @@ def merge_cli_overrides(
     packages: Optional[Iterable[str]] = None,
     exclude_dirs: Optional[Iterable[str]] = None,
     exclude_suffixes: Optional[Iterable[str]] = None,
+    ignore_file: Optional[str] = None,
 ) -> CodegraphConfig:
     """Return a new config with CLI-provided values taking precedence.
 
@@ -118,6 +124,7 @@ def merge_cli_overrides(
         packages=list(config.packages),
         exclude_dirs=set(config.exclude_dirs),
         exclude_suffixes=tuple(config.exclude_suffixes),
+        ignore_file=config.ignore_file,
         source=config.source,
     )
     if packages:
@@ -126,6 +133,8 @@ def merge_cli_overrides(
         merged.exclude_dirs = set(exclude_dirs)
     if exclude_suffixes:
         merged.exclude_suffixes = tuple(exclude_suffixes)
+    if ignore_file:
+        merged.ignore_file = ignore_file
     return merged
 
 
@@ -167,9 +176,13 @@ def _build_config(data: dict, *, source: str) -> CodegraphConfig:
     exclude_suffixes = data.get("exclude_suffixes", [])
     if not isinstance(exclude_suffixes, list) or not all(isinstance(p, str) for p in exclude_suffixes):
         raise ConfigError(f"{source}: `exclude_suffixes` must be a list of strings")
+    ignore_file = data.get("ignore_file")
+    if ignore_file is not None and not isinstance(ignore_file, str):
+        raise ConfigError(f"{source}: `ignore_file` must be a string")
     return CodegraphConfig(
         packages=list(packages),
         exclude_dirs=set(exclude_dirs),
         exclude_suffixes=tuple(exclude_suffixes),
+        ignore_file=ignore_file,
         source=source,
     )

--- a/codegraph/codegraph/framework.py
+++ b/codegraph/codegraph/framework.py
@@ -1,0 +1,401 @@
+"""Per-package framework detection.
+
+Scans a package directory (must contain ``package.json`` for most frameworks —
+Odoo is the one exception) and returns a :class:`FrameworkInfo` describing the
+detected framework, version, TypeScript usage, router, state management, UI
+library, build tool, and package manager.
+
+The detector is scored: file existence adds 30 points, matching ``package.json``
+dependency adds 25, a code-regex hit adds 15. Below 25 total the framework is
+marked ``UNKNOWN``. The score normalised to ``[0, 1]`` is surfaced as
+:attr:`FrameworkInfo.confidence`.
+
+Ported from ``agent-onboarding/architect/analyzer/framework_detector.py``
+(Apache-2.0). Stripped: ``get_source_directories`` and
+``get_component_file_extensions`` — codegraph drives its own walk in
+:func:`codegraph.cli._run_index` and doesn't need the detector dictating where
+to look.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+class FrameworkType(Enum):
+    REACT = "react"
+    REACT_TYPESCRIPT = "react-typescript"
+    NEXTJS = "nextjs"
+    VUE = "vue"
+    VUE3 = "vue3"
+    ANGULAR = "angular"
+    SVELTE = "svelte"
+    SVELTEKIT = "sveltekit"
+    ODOO = "odoo"
+    UNKNOWN = "unknown"
+
+
+# Human-friendly display names — used for :Package.framework in Neo4j so that
+# queries like `MATCH (:Package {framework:'Next.js'})` read naturally.
+FRAMEWORK_DISPLAY = {
+    FrameworkType.REACT: "React",
+    FrameworkType.REACT_TYPESCRIPT: "React (TypeScript)",
+    FrameworkType.NEXTJS: "Next.js",
+    FrameworkType.VUE: "Vue",
+    FrameworkType.VUE3: "Vue 3",
+    FrameworkType.ANGULAR: "Angular",
+    FrameworkType.SVELTE: "Svelte",
+    FrameworkType.SVELTEKIT: "SvelteKit",
+    FrameworkType.ODOO: "Odoo",
+    FrameworkType.UNKNOWN: "Unknown",
+}
+
+
+@dataclass
+class FrameworkInfo:
+    framework: FrameworkType
+    version: Optional[str] = None
+    typescript: bool = False
+    styling: list[str] = field(default_factory=list)
+    router: Optional[str] = None
+    state_management: list[str] = field(default_factory=list)
+    ui_library: Optional[str] = None
+    build_tool: Optional[str] = None
+    package_manager: Optional[str] = None
+    confidence: float = 0.0
+
+    @property
+    def display_name(self) -> str:
+        return FRAMEWORK_DISPLAY.get(self.framework, self.framework.value)
+
+
+class FrameworkDetector:
+    """Scored heuristic detector over ``package.json`` + config files + code."""
+
+    FRAMEWORK_INDICATORS = {
+        FrameworkType.NEXTJS: {
+            "files": ["next.config.js", "next.config.mjs", "next.config.ts", ".next"],
+            "dependencies": ["next"],
+            "patterns": [r"from\s+['\"]next", r"import.*from\s+['\"]next"],
+        },
+        FrameworkType.REACT: {
+            "files": [],
+            "dependencies": ["react", "react-dom"],
+            "patterns": [r"from\s+['\"]react['\"]", r"import\s+React"],
+        },
+        FrameworkType.VUE3: {
+            "files": ["vue.config.js", "vite.config.ts", "vite.config.js"],
+            "dependencies": ["vue"],
+            "patterns": [r"<script\s+setup", r"defineComponent", r"from\s+['\"]vue['\"]"],
+        },
+        FrameworkType.ANGULAR: {
+            "files": ["angular.json", ".angular"],
+            "dependencies": ["@angular/core", "@angular/cli"],
+            "patterns": [r"@Component", r"@Injectable", r"@NgModule"],
+        },
+        FrameworkType.SVELTEKIT: {
+            "files": ["svelte.config.js", "svelte.config.ts"],
+            "dependencies": ["@sveltejs/kit"],
+            "patterns": [r"<script.*lang=['\"]ts['\"]", r"from\s+['\"]svelte['\"]"],
+        },
+        FrameworkType.SVELTE: {
+            "files": [],
+            "dependencies": ["svelte"],
+            "patterns": [r"\.svelte$", r"<script>.*</script>.*<style>"],
+        },
+        FrameworkType.ODOO: {
+            "files": ["odoo-bin", "__manifest__.py", "__openerp__.py"],
+            "dependencies": [],
+            "patterns": [
+                r"<odoo>",
+                r"ir\.actions\.act_window",
+                r"_name\s*=\s*['\"]\w+\.\w+['\"]",
+            ],
+        },
+    }
+
+    STYLING_INDICATORS = {
+        "tailwind": ["tailwind.config.js", "tailwind.config.ts", "tailwindcss"],
+        "css-modules": [r"\.module\.css$", r"\.module\.scss$"],
+        "styled-components": ["styled-components"],
+        "emotion": ["@emotion/react", "@emotion/styled"],
+        "sass": ["sass", "node-sass"],
+        "less": ["less"],
+        "chakra": ["@chakra-ui/react"],
+        "material-ui": ["@mui/material", "@material-ui/core"],
+        "ant-design": ["antd"],
+        "bootstrap": ["bootstrap", "react-bootstrap"],
+    }
+
+    ROUTER_INDICATORS = {
+        "react-router": ["react-router", "react-router-dom"],
+        "next/router": ["next/router", "next/navigation"],
+        "vue-router": ["vue-router"],
+        "@angular/router": ["@angular/router"],
+        "svelte-routing": ["svelte-routing", "@sveltejs/kit"],
+    }
+
+    STATE_INDICATORS = {
+        "redux": ["redux", "@reduxjs/toolkit", "react-redux"],
+        "zustand": ["zustand"],
+        "jotai": ["jotai"],
+        "recoil": ["recoil"],
+        "mobx": ["mobx", "mobx-react"],
+        "pinia": ["pinia"],
+        "vuex": ["vuex"],
+        "ngrx": ["@ngrx/store"],
+    }
+
+    UI_LIBRARY_INDICATORS = {
+        "material-ui": ["@mui/material", "@material-ui/core"],
+        "ant-design": ["antd"],
+        "chakra-ui": ["@chakra-ui/react"],
+        "mantine": ["@mantine/core"],
+        "shadcn": ["@radix-ui/react"],
+        "headless-ui": ["@headlessui/react"],
+        "bootstrap": ["react-bootstrap", "bootstrap-vue"],
+        "vuetify": ["vuetify"],
+        "primevue": ["primevue"],
+        "element-plus": ["element-plus"],
+        "ng-zorro": ["ng-zorro-antd"],
+    }
+
+    BUILD_TOOL_INDICATORS = {
+        "vite": ["vite.config.js", "vite.config.ts", "vite"],
+        "webpack": ["webpack.config.js", "webpack"],
+        "turbopack": ["turbopack"],
+        "esbuild": ["esbuild"],
+        "rollup": ["rollup.config.js", "rollup"],
+        "parcel": [".parcelrc", "parcel"],
+    }
+
+    def __init__(self, project_path: Path) -> None:
+        self.project_path = Path(project_path)
+        self._package_json: Optional[dict] = None
+        self._files_cache: Optional[list[Path]] = None
+
+    # ── package.json / dependency helpers ───────────────────────────────
+
+    @property
+    def package_json(self) -> Optional[dict]:
+        if self._package_json is None:
+            p = self.project_path / "package.json"
+            if p.exists():
+                try:
+                    self._package_json = json.loads(p.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    self._package_json = None
+        return self._package_json
+
+    @property
+    def all_dependencies(self) -> set[str]:
+        pj = self.package_json
+        if not pj:
+            return set()
+        deps: set[str] = set()
+        for key in ("dependencies", "devDependencies", "peerDependencies"):
+            section = pj.get(key)
+            if isinstance(section, dict):
+                deps.update(section.keys())
+        return deps
+
+    def _get_dependency_version(self, dep: str) -> Optional[str]:
+        pj = self.package_json
+        if not pj:
+            return None
+        for key in ("dependencies", "devDependencies", "peerDependencies"):
+            section = pj.get(key)
+            if isinstance(section, dict) and dep in section:
+                return section[dep]
+        return None
+
+    def _check_file_exists(self, filename: str) -> bool:
+        return (self.project_path / filename).exists()
+
+    def _check_dependency(self, dep: str) -> bool:
+        return dep in self.all_dependencies
+
+    # ── file scanning ───────────────────────────────────────────────────
+
+    def _get_all_files(self) -> list[Path]:
+        if self._files_cache is None:
+            ignore = {
+                "node_modules", ".git", ".next", "dist", "build",
+                ".nuxt", ".svelte-kit", ".angular", "__pycache__",
+            }
+            files: list[Path] = []
+            for item in self.project_path.rglob("*"):
+                if item.is_file() and not any(part in ignore for part in item.parts):
+                    files.append(item)
+            self._files_cache = files
+        return self._files_cache
+
+    def _check_pattern_in_files(self, pattern: str, extensions: tuple[str, ...]) -> bool:
+        regex = re.compile(pattern)
+        for file_path in self._get_all_files():
+            if file_path.suffix not in extensions:
+                continue
+            try:
+                content = file_path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if regex.search(content):
+                return True
+        return False
+
+    # ── per-aspect detection ────────────────────────────────────────────
+
+    def _detect_typescript(self) -> bool:
+        if self._check_file_exists("tsconfig.json") or self._check_file_exists("tsconfig.base.json"):
+            return True
+        if self._check_dependency("typescript"):
+            return True
+        for file_path in self._get_all_files():
+            if file_path.suffix in (".ts", ".tsx"):
+                return True
+        return False
+
+    def _detect_styling(self) -> list[str]:
+        detected: set[str] = set()
+        for name, indicators in self.STYLING_INDICATORS.items():
+            for indicator in indicators:
+                if indicator.startswith(r"\."):
+                    regex = re.compile(indicator)
+                    if any(regex.search(str(p)) for p in self._get_all_files()):
+                        detected.add(name)
+                        break
+                elif self._check_file_exists(indicator) or self._check_dependency(indicator):
+                    detected.add(name)
+                    break
+        return sorted(detected)
+
+    def _detect_router(self) -> Optional[str]:
+        for name, deps in self.ROUTER_INDICATORS.items():
+            if any(self._check_dependency(d) for d in deps):
+                return name
+        return None
+
+    def _detect_state_management(self) -> list[str]:
+        detected: list[str] = []
+        for name, deps in self.STATE_INDICATORS.items():
+            if any(self._check_dependency(d) for d in deps):
+                detected.append(name)
+        return detected
+
+    def _detect_ui_library(self) -> Optional[str]:
+        for name, deps in self.UI_LIBRARY_INDICATORS.items():
+            if any(self._check_dependency(d) for d in deps):
+                return name
+        return None
+
+    def _detect_build_tool(self) -> Optional[str]:
+        for name, indicators in self.BUILD_TOOL_INDICATORS.items():
+            for indicator in indicators:
+                if self._check_file_exists(indicator) or self._check_dependency(indicator):
+                    return name
+        return None
+
+    def _detect_package_manager(self) -> Optional[str]:
+        if self._check_file_exists("pnpm-lock.yaml"):
+            return "pnpm"
+        if self._check_file_exists("yarn.lock"):
+            return "yarn"
+        if self._check_file_exists("package-lock.json"):
+            return "npm"
+        if self._check_file_exists("bun.lockb") or self._check_file_exists("bun.lock"):
+            return "bun"
+        return None
+
+    # ── Odoo short-circuit ──────────────────────────────────────────────
+
+    def _has_odoo_signature(self) -> bool:
+        if self._check_file_exists("__manifest__.py") or self._check_file_exists("__openerp__.py"):
+            return True
+        for candidate in self.project_path.rglob("__manifest__.py"):
+            if "node_modules" in candidate.parts:
+                continue
+            return True
+        count = 0
+        for file_path in self._get_all_files():
+            if file_path.suffix != ".xml":
+                continue
+            try:
+                snippet = file_path.read_text(encoding="utf-8", errors="ignore")[:2000]
+            except OSError:
+                continue
+            if "<odoo>" in snippet or "ir.actions.act_window" in snippet:
+                return True
+            count += 1
+            if count >= 30:
+                break
+        return False
+
+    # ── main entry point ────────────────────────────────────────────────
+
+    def detect(self) -> FrameworkInfo:
+        if self._has_odoo_signature():
+            return FrameworkInfo(
+                framework=FrameworkType.ODOO,
+                version=None,
+                typescript=False,
+                styling=[],
+                router="odoo-menu-router",
+                state_management=[],
+                ui_library="odoo-web",
+                build_tool=None,
+                package_manager=None,
+                confidence=0.95,
+            )
+
+        scores: dict[FrameworkType, float] = {ft: 0.0 for ft in FrameworkType}
+        code_extensions = (".js", ".jsx", ".ts", ".tsx", ".vue", ".svelte")
+
+        for framework, indicators in self.FRAMEWORK_INDICATORS.items():
+            for file_indicator in indicators["files"]:
+                if self._check_file_exists(file_indicator):
+                    scores[framework] += 30.0
+            for dep in indicators["dependencies"]:
+                if self._check_dependency(dep):
+                    scores[framework] += 25.0
+            for pattern in indicators["patterns"]:
+                if self._check_pattern_in_files(pattern, code_extensions):
+                    scores[framework] += 15.0
+
+        best_framework = max(scores, key=scores.get)
+        best_score = scores[best_framework]
+
+        is_typescript = self._detect_typescript()
+        if best_framework == FrameworkType.REACT and is_typescript:
+            best_framework = FrameworkType.REACT_TYPESCRIPT
+
+        if best_score < 25.0:
+            best_framework = FrameworkType.UNKNOWN
+
+        version: Optional[str] = None
+        if best_framework in (FrameworkType.REACT, FrameworkType.REACT_TYPESCRIPT):
+            version = self._get_dependency_version("react")
+        elif best_framework == FrameworkType.NEXTJS:
+            version = self._get_dependency_version("next")
+        elif best_framework in (FrameworkType.VUE, FrameworkType.VUE3):
+            version = self._get_dependency_version("vue")
+        elif best_framework == FrameworkType.ANGULAR:
+            version = self._get_dependency_version("@angular/core")
+        elif best_framework in (FrameworkType.SVELTE, FrameworkType.SVELTEKIT):
+            version = self._get_dependency_version("svelte")
+
+        return FrameworkInfo(
+            framework=best_framework,
+            version=version,
+            typescript=is_typescript,
+            styling=self._detect_styling(),
+            router=self._detect_router(),
+            state_management=self._detect_state_management(),
+            ui_library=self._detect_ui_library(),
+            build_tool=self._detect_build_tool(),
+            package_manager=self._detect_package_manager(),
+            confidence=min(best_score / 100.0, 1.0),
+        )

--- a/codegraph/codegraph/framework.py
+++ b/codegraph/codegraph/framework.py
@@ -18,6 +18,7 @@ to look.
 """
 from __future__ import annotations
 
+import copy
 import json
 import re
 from dataclasses import dataclass, field
@@ -189,6 +190,7 @@ class FrameworkDetector:
         self._package_json: Optional[dict] = None
         self._files_cache: Optional[list[Path]] = None
         self._workspace_deps_cache: Optional[set[str]] = None
+        self._workspace_pjs_cache: Optional[list[dict]] = None
 
     # ── monorepo walk-up ────────────────────────────────────────────────
 
@@ -225,24 +227,27 @@ class FrameworkDetector:
                     self._package_json = None
         return self._package_json
 
-    @property
-    def _workspace_dependencies(self) -> set[str]:
-        """Deps from the package's own ``package.json`` plus any parent
-        ``package.json`` found walking up that declares a ``workspaces`` field.
+    def _workspace_package_jsons(self) -> list[dict]:
+        """Parse and cache every relevant ``package.json`` walking up.
+
+        Order: own package.json first (most specific), then ancestor
+        ``package.json`` files that declare a ``workspaces`` field. Parsed
+        once on first access and reused by :attr:`_workspace_dependencies`
+        and :meth:`_get_dependency_version`.
 
         The ``workspaces`` guard prevents leakage: if codegraph is run from a
         subdirectory of an unrelated enclosing project, that parent's deps
         won't be picked up unless it's explicitly a monorepo root.
         """
-        if self._workspace_deps_cache is not None:
-            return self._workspace_deps_cache
+        if self._workspace_pjs_cache is not None:
+            return self._workspace_pjs_cache
 
-        merged: set[str] = set()
+        pjs: list[dict] = []
         if self.package_json:
-            for key in ("dependencies", "devDependencies", "peerDependencies"):
-                section = self.package_json.get(key)
-                if isinstance(section, dict):
-                    merged.update(section.keys())
+            # Deep-copy the own package.json so mutation of the cached list
+            # can't corrupt self._package_json. Parent package.jsons (below)
+            # are freshly parsed per walk-up call and don't need this.
+            pjs.append(copy.deepcopy(self.package_json))
 
         for path in self._walk_up_to_repo_root():
             if path == self.project_path:
@@ -256,6 +261,19 @@ class FrameworkDetector:
                 continue
             if "workspaces" not in pj:
                 continue
+            pjs.append(pj)
+
+        self._workspace_pjs_cache = pjs
+        return pjs
+
+    @property
+    def _workspace_dependencies(self) -> set[str]:
+        """Merged dep names from own + workspace-root ``package.json`` files."""
+        if self._workspace_deps_cache is not None:
+            return self._workspace_deps_cache
+
+        merged: set[str] = set()
+        for pj in self._workspace_package_jsons():
             for key in ("dependencies", "devDependencies", "peerDependencies"):
                 section = pj.get(key)
                 if isinstance(section, dict):
@@ -269,29 +287,11 @@ class FrameworkDetector:
         return self._workspace_dependencies
 
     def _get_dependency_version(self, dep: str) -> Optional[str]:
-        # Own package.json first — most specific.
-        pj = self.package_json
-        if pj:
+        """Return the version string for ``dep`` from the first
+        ``package.json`` (own → workspace-root) that declares it."""
+        for pj in self._workspace_package_jsons():
             for key in ("dependencies", "devDependencies", "peerDependencies"):
                 section = pj.get(key)
-                if isinstance(section, dict) and dep in section:
-                    return section[dep]
-
-        # Fall back to workspace-root package.json for hoisted deps.
-        for path in self._walk_up_to_repo_root():
-            if path == self.project_path:
-                continue
-            pj_path = path / "package.json"
-            if not pj_path.exists():
-                continue
-            try:
-                parent_pj = json.loads(pj_path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                continue
-            if "workspaces" not in parent_pj:
-                continue
-            for key in ("dependencies", "devDependencies", "peerDependencies"):
-                section = parent_pj.get(key)
                 if isinstance(section, dict) and dep in section:
                     return section[dep]
         return None

--- a/codegraph/codegraph/framework.py
+++ b/codegraph/codegraph/framework.py
@@ -23,7 +23,7 @@ import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 
 class FrameworkType(Enum):
@@ -35,6 +35,7 @@ class FrameworkType(Enum):
     ANGULAR = "angular"
     SVELTE = "svelte"
     SVELTEKIT = "sveltekit"
+    NESTJS = "nestjs"
     ODOO = "odoo"
     UNKNOWN = "unknown"
 
@@ -50,6 +51,7 @@ FRAMEWORK_DISPLAY = {
     FrameworkType.ANGULAR: "Angular",
     FrameworkType.SVELTE: "Svelte",
     FrameworkType.SVELTEKIT: "SvelteKit",
+    FrameworkType.NESTJS: "NestJS",
     FrameworkType.ODOO: "Odoo",
     FrameworkType.UNKNOWN: "Unknown",
 }
@@ -77,6 +79,15 @@ class FrameworkDetector:
     """Scored heuristic detector over ``package.json`` + config files + code."""
 
     FRAMEWORK_INDICATORS = {
+        FrameworkType.NESTJS: {
+            "files": ["nest-cli.json"],
+            "dependencies": ["@nestjs/core", "@nestjs/common"],
+            "patterns": [
+                r"@Module\s*\(",
+                r"@Injectable\s*\(",
+                r"@Controller\s*\(",
+            ],
+        },
         FrameworkType.NEXTJS: {
             "files": ["next.config.js", "next.config.mjs", "next.config.ts", ".next"],
             "dependencies": ["next"],
@@ -177,6 +188,29 @@ class FrameworkDetector:
         self.project_path = Path(project_path)
         self._package_json: Optional[dict] = None
         self._files_cache: Optional[list[Path]] = None
+        self._workspace_deps_cache: Optional[set[str]] = None
+
+    # ── monorepo walk-up ────────────────────────────────────────────────
+
+    def _walk_up_to_repo_root(self, max_hops: int = 10) -> Iterator[Path]:
+        """Yield ``project_path`` then each parent, stopping at a git root
+        or the filesystem root.
+
+        A directory is considered the git root if it contains a ``.git``
+        entry (file or directory — git worktrees use a file). The iterator
+        *yields* that git-root path before terminating. ``max_hops`` caps
+        the walk at 10 — no real monorepo nests that deep, and this keeps
+        pathological invocations bounded.
+        """
+        current = self.project_path
+        for _ in range(max_hops):
+            yield current
+            if (current / ".git").exists():
+                return
+            parent = current.parent
+            if parent == current:
+                return
+            current = parent
 
     # ── package.json / dependency helpers ───────────────────────────────
 
@@ -192,25 +226,74 @@ class FrameworkDetector:
         return self._package_json
 
     @property
+    def _workspace_dependencies(self) -> set[str]:
+        """Deps from the package's own ``package.json`` plus any parent
+        ``package.json`` found walking up that declares a ``workspaces`` field.
+
+        The ``workspaces`` guard prevents leakage: if codegraph is run from a
+        subdirectory of an unrelated enclosing project, that parent's deps
+        won't be picked up unless it's explicitly a monorepo root.
+        """
+        if self._workspace_deps_cache is not None:
+            return self._workspace_deps_cache
+
+        merged: set[str] = set()
+        if self.package_json:
+            for key in ("dependencies", "devDependencies", "peerDependencies"):
+                section = self.package_json.get(key)
+                if isinstance(section, dict):
+                    merged.update(section.keys())
+
+        for path in self._walk_up_to_repo_root():
+            if path == self.project_path:
+                continue
+            pj_path = path / "package.json"
+            if not pj_path.exists():
+                continue
+            try:
+                pj = json.loads(pj_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if "workspaces" not in pj:
+                continue
+            for key in ("dependencies", "devDependencies", "peerDependencies"):
+                section = pj.get(key)
+                if isinstance(section, dict):
+                    merged.update(section.keys())
+
+        self._workspace_deps_cache = merged
+        return merged
+
+    @property
     def all_dependencies(self) -> set[str]:
-        pj = self.package_json
-        if not pj:
-            return set()
-        deps: set[str] = set()
-        for key in ("dependencies", "devDependencies", "peerDependencies"):
-            section = pj.get(key)
-            if isinstance(section, dict):
-                deps.update(section.keys())
-        return deps
+        return self._workspace_dependencies
 
     def _get_dependency_version(self, dep: str) -> Optional[str]:
+        # Own package.json first — most specific.
         pj = self.package_json
-        if not pj:
-            return None
-        for key in ("dependencies", "devDependencies", "peerDependencies"):
-            section = pj.get(key)
-            if isinstance(section, dict) and dep in section:
-                return section[dep]
+        if pj:
+            for key in ("dependencies", "devDependencies", "peerDependencies"):
+                section = pj.get(key)
+                if isinstance(section, dict) and dep in section:
+                    return section[dep]
+
+        # Fall back to workspace-root package.json for hoisted deps.
+        for path in self._walk_up_to_repo_root():
+            if path == self.project_path:
+                continue
+            pj_path = path / "package.json"
+            if not pj_path.exists():
+                continue
+            try:
+                parent_pj = json.loads(pj_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if "workspaces" not in parent_pj:
+                continue
+            for key in ("dependencies", "devDependencies", "peerDependencies"):
+                section = parent_pj.get(key)
+                if isinstance(section, dict) and dep in section:
+                    return section[dep]
         return None
 
     def _check_file_exists(self, filename: str) -> bool:
@@ -300,14 +383,21 @@ class FrameworkDetector:
         return None
 
     def _detect_package_manager(self) -> Optional[str]:
-        if self._check_file_exists("pnpm-lock.yaml"):
-            return "pnpm"
-        if self._check_file_exists("yarn.lock"):
-            return "yarn"
-        if self._check_file_exists("package-lock.json"):
-            return "npm"
-        if self._check_file_exists("bun.lockb") or self._check_file_exists("bun.lock"):
-            return "bun"
+        """Walk up from the package root looking for a lockfile.
+
+        Monorepos store the lockfile at the repo root, not at each package
+        root — so checking only :attr:`project_path` misses it. We walk up
+        until a lockfile is found or we hit the git/filesystem root.
+        """
+        for path in self._walk_up_to_repo_root():
+            if (path / "pnpm-lock.yaml").exists():
+                return "pnpm"
+            if (path / "yarn.lock").exists():
+                return "yarn"
+            if (path / "package-lock.json").exists():
+                return "npm"
+            if (path / "bun.lockb").exists() or (path / "bun.lock").exists():
+                return "bun"
         return None
 
     # ── Odoo short-circuit ──────────────────────────────────────────────
@@ -386,6 +476,8 @@ class FrameworkDetector:
             version = self._get_dependency_version("@angular/core")
         elif best_framework in (FrameworkType.SVELTE, FrameworkType.SVELTEKIT):
             version = self._get_dependency_version("svelte")
+        elif best_framework == FrameworkType.NESTJS:
+            version = self._get_dependency_version("@nestjs/core")
 
         return FrameworkInfo(
             framework=best_framework,

--- a/codegraph/codegraph/ignore.py
+++ b/codegraph/codegraph/ignore.py
@@ -1,0 +1,186 @@
+"""`.codegraphignore` — user-controlled exclusion of files, routes, and components.
+
+Drop a ``.codegraphignore`` at the repo root (or point at any other file with
+``--ignore-file``). Patterns use gitignore-style globs plus two codegraph
+extensions:
+
+- ``@route:/admin/*`` — matches against :class:`~.schema.RouteNode.path`
+- ``@component:*Admin*`` — matches against function / class component names
+- ``!pattern`` negation works for all three
+
+codegraph's built-in :data:`~.config.BASE_EXCLUDE_DIRS` still prunes the walk
+first (fast ``set`` check on path components). :class:`IgnoreFilter` only runs
+on the survivors, so it never competes with the cheap fast-path.
+"""
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+class IgnoreConfigError(Exception):
+    """Raised when a ``.codegraphignore`` file cannot be read or parsed."""
+
+
+@dataclass
+class IgnorePattern:
+    pattern: str
+    pattern_type: str  # "file" | "route" | "component"
+    is_negation: bool = False
+    regex: Optional[re.Pattern] = None
+
+
+@dataclass
+class IgnoreConfig:
+    file_patterns: list[IgnorePattern] = field(default_factory=list)
+    route_patterns: list[IgnorePattern] = field(default_factory=list)
+    component_patterns: list[IgnorePattern] = field(default_factory=list)
+    raw_patterns: list[str] = field(default_factory=list)
+
+
+class IgnoreFilter:
+    """Filters files, routes, and components against a ``.codegraphignore`` file.
+
+    Unlike the upstream agent-onboarding version, this class ships **no default
+    patterns** — codegraph's :data:`~.config.BASE_EXCLUDE_DIRS` already handles
+    build artefacts, and opinionated admin-route defaults don't belong in a
+    generic indexer. Users opt in by writing patterns themselves.
+    """
+
+    def __init__(self, ignore_path: Path) -> None:
+        self.ignore_path = Path(ignore_path).resolve()
+        self.config = IgnoreConfig()
+        if not self.ignore_path.exists():
+            raise IgnoreConfigError(f"{self.ignore_path} not found")
+        try:
+            content = self.ignore_path.read_text(encoding="utf-8")
+        except OSError as e:
+            raise IgnoreConfigError(f"Cannot read {self.ignore_path}: {e}") from e
+        self._parse_patterns(content)
+
+    # ── parsing ─────────────────────────────────────────────────────────
+
+    def _parse_patterns(self, content: str) -> None:
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            self.config.raw_patterns.append(line)
+
+            is_negation = line.startswith("!")
+            if is_negation:
+                line = line[1:]
+
+            if line.startswith("@route:"):
+                pattern = line[len("@route:"):]
+                self.config.route_patterns.append(IgnorePattern(
+                    pattern=pattern,
+                    pattern_type="route",
+                    is_negation=is_negation,
+                    regex=self._glob_to_regex(pattern),
+                ))
+            elif line.startswith("@component:"):
+                pattern = line[len("@component:"):]
+                self.config.component_patterns.append(IgnorePattern(
+                    pattern=pattern,
+                    pattern_type="component",
+                    is_negation=is_negation,
+                    regex=self._glob_to_regex(pattern),
+                ))
+            else:
+                self.config.file_patterns.append(IgnorePattern(
+                    pattern=line,
+                    pattern_type="file",
+                    is_negation=is_negation,
+                    regex=self._gitignore_to_regex(line),
+                ))
+
+    @staticmethod
+    def _glob_to_regex(pattern: str) -> re.Pattern:
+        """Convert a simple ``*``/``**``/``?`` glob into a regex.
+
+        Used for ``@route:`` and ``@component:`` patterns where we want
+        substring-style matching (no leading-slash semantics).
+        """
+        escaped = re.escape(pattern)
+        escaped = escaped.replace(r"\*\*", ".*")
+        escaped = escaped.replace(r"\*", "[^/]*")
+        escaped = escaped.replace(r"\?", ".")
+        return re.compile(f"^{escaped}$", re.IGNORECASE)
+
+    @staticmethod
+    def _gitignore_to_regex(pattern: str) -> re.Pattern:
+        """Convert a gitignore-style glob into a regex.
+
+        Handles leading slash (root anchor), trailing slash (directory only),
+        ``**`` (any number of path components), ``*`` (within one component),
+        and ``?`` (single non-slash character).
+        """
+        if pattern.startswith("/"):
+            pattern = pattern[1:]
+            anchored = True
+        else:
+            anchored = False
+
+        escaped = re.escape(pattern)
+        escaped = escaped.replace(r"\*\*/", "(?:.*/)?")
+        escaped = escaped.replace(r"/\*\*", "(?:/.*)?")
+        escaped = escaped.replace(r"\*\*", ".*")
+        escaped = escaped.replace(r"\*", "[^/]*")
+        escaped = escaped.replace(r"\?", "[^/]")
+
+        if escaped.endswith("/"):
+            escaped = escaped[:-1] + "(?:/.*)?"
+
+        if anchored:
+            regex_pattern = f"^{escaped}(?:/.*)?$"
+        else:
+            regex_pattern = f"(?:^|/){escaped}(?:/.*)?$"
+
+        return re.compile(regex_pattern, re.IGNORECASE)
+
+    # ── predicates ──────────────────────────────────────────────────────
+
+    def should_ignore_file(self, file_path: str) -> bool:
+        path = file_path.replace("\\", "/")
+        if path.startswith("./"):
+            path = path[2:]
+        decision = False
+        for pattern in self.config.file_patterns:
+            if pattern.regex and pattern.regex.search(path):
+                decision = not pattern.is_negation
+        return decision
+
+    def should_ignore_route(self, route_path: str) -> bool:
+        if not route_path.startswith("/"):
+            route_path = "/" + route_path
+        decision = False
+        for pattern in self.config.route_patterns:
+            if pattern.regex and pattern.regex.search(route_path):
+                decision = not pattern.is_negation
+            elif fnmatch.fnmatch(route_path, pattern.pattern):
+                decision = not pattern.is_negation
+        return decision
+
+    def should_ignore_component(self, component_name: str) -> bool:
+        decision = False
+        for pattern in self.config.component_patterns:
+            if pattern.regex and pattern.regex.search(component_name):
+                decision = not pattern.is_negation
+            elif fnmatch.fnmatch(component_name, pattern.pattern):
+                decision = not pattern.is_negation
+        return decision
+
+    # ── helpers ─────────────────────────────────────────────────────────
+
+    def counts(self) -> tuple[int, int, int]:
+        """Return ``(files, routes, components)`` pattern counts."""
+        return (
+            len(self.config.file_patterns),
+            len(self.config.route_patterns),
+            len(self.config.component_patterns),
+        )

--- a/codegraph/codegraph/loader.py
+++ b/codegraph/codegraph/loader.py
@@ -625,7 +625,8 @@ def _write_per_file_extras(session, index: Index, stats: LoadStats) -> None:
         MATCH (a:Atom {name: r.atom_name})
         MERGE (fn)-[:READS_ATOM]->(a)
     """, atom_reads)
-    stats.edges[READS_ATOM] = len(atom_reads)
+    rec = session.run("MATCH ()-[r:READS_ATOM]->() RETURN count(r) AS v").single()
+    stats.edges[READS_ATOM] = int(rec["v"]) if rec else 0
 
     _run(session, """
         UNWIND $rows AS r
@@ -633,7 +634,8 @@ def _write_per_file_extras(session, index: Index, stats: LoadStats) -> None:
         MATCH (a:Atom {name: r.atom_name})
         MERGE (fn)-[:WRITES_ATOM]->(a)
     """, atom_writes)
-    stats.edges[WRITES_ATOM] = len(atom_writes)
+    rec = session.run("MATCH ()-[r:WRITES_ATOM]->() RETURN count(r) AS v").single()
+    stats.edges[WRITES_ATOM] = int(rec["v"]) if rec else 0
 
     _run(session, """
         UNWIND $rows AS r

--- a/codegraph/codegraph/loader.py
+++ b/codegraph/codegraph/loader.py
@@ -1,6 +1,7 @@
 """Neo4j writer: constraints, batched UNWIND-MERGE, idempotent. Phases 1-8."""
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Iterable
 
@@ -51,6 +52,8 @@ from .schema import (
     USES_OPERATION,
     WRITES_ATOM,
 )
+
+log = logging.getLogger(__name__)
 
 
 BATCH = 1000
@@ -444,6 +447,7 @@ def _write_edges(session, edges: list[Edge], stats: LoadStats) -> None:
     # Partition
     buckets: dict[str, list] = {}
     dec_class: list = []
+    dec_func: list = []
     dec_method: list = []
 
     for e in edges:
@@ -454,8 +458,12 @@ def _write_edges(session, edges: list[Edge], stats: LoadStats) -> None:
             dname = e.dst_id[len("dec:"):]
             if e.src_id.startswith("class:"):
                 dec_class.append(dict(src=e.src_id, name=dname))
+            elif e.src_id.startswith("func:"):
+                dec_func.append(dict(src=e.src_id, name=dname))
             elif e.src_id.startswith("method:"):
                 dec_method.append(dict(src=e.src_id, name=dname))
+            else:
+                log.debug("DECORATED_BY edge with unknown src prefix dropped: %r", e.src_id)
             continue
 
         if e.kind == IMPORTS:
@@ -657,11 +665,17 @@ def _write_edges(session, edges: list[Edge], stats: LoadStats) -> None:
     """, dec_class)
     _run(session, """
         UNWIND $rows AS r
+        MATCH (a:Function {id: r.src})
+        MATCH (d:Decorator {name: r.name})
+        MERGE (a)-[:DECORATED_BY]->(d)
+    """, dec_func)
+    _run(session, """
+        UNWIND $rows AS r
         MATCH (a:Method {id: r.src})
         MATCH (d:Decorator {name: r.name})
         MERGE (a)-[:DECORATED_BY]->(d)
     """, dec_method)
-    stats.edges[DECORATED_BY] = len(dec_class) + len(dec_method)
+    stats.edges[DECORATED_BY] = len(dec_class) + len(dec_func) + len(dec_method)
 
 
 def _write_per_file_extras(session, index: Index, stats: LoadStats) -> None:

--- a/codegraph/codegraph/loader.py
+++ b/codegraph/codegraph/loader.py
@@ -557,20 +557,21 @@ def _write_edges(session, edges: list[Edge], stats: LoadStats) -> None:
     """, buckets.get(CALLS, []))
     stats.edges[CALLS] = len(buckets.get(CALLS, []))
 
+    handles_endpoint = [r for r in buckets.get(HANDLES, []) if r["dst"].startswith("endpoint:")]
+    handles_gqlop = [r for r in buckets.get(HANDLES, []) if r["dst"].startswith("gqlop:")]
     _run(session, """
         UNWIND $rows AS r
         MATCH (m:Method {id: r.src})
         MATCH (e:Endpoint {id: r.dst})
         MERGE (m)-[:HANDLES]->(e)
-    """, [row for row in buckets.get(HANDLES, []) if ":Endpoint" or "endpoint:" in row["dst"]])
-    # Also method -> GraphQL operation for HANDLES (distinct query)
+    """, handles_endpoint)
     _run(session, """
         UNWIND $rows AS r
         MATCH (m:Method {id: r.src})
         MATCH (o:GraphQLOperation {id: r.dst})
         MERGE (m)-[:HANDLES]->(o)
-    """, buckets.get(HANDLES, []))
-    stats.edges[HANDLES] = len(buckets.get(HANDLES, []))
+    """, handles_gqlop)
+    stats.edges[HANDLES] = len(handles_endpoint) + len(handles_gqlop)
 
     # Decorator edges
     _run(session, """
@@ -710,8 +711,6 @@ def _write_ownership(session, ownership: dict, stats: LoadStats) -> None:
     contribs = ownership.get("contributors", [])
     owned = ownership.get("owned_by", [])
 
-    _run(session, "UNWIND $rows AS r MERGE (:Author {email: r.email}) SET email = r.email",
-         [dict(email=a["email"], name=a.get("name", "")) for a in authors])
     _run(session, """
         UNWIND $rows AS r
         MERGE (a:Author {email: r.email})

--- a/codegraph/codegraph/loader.py
+++ b/codegraph/codegraph/loader.py
@@ -241,13 +241,17 @@ class Neo4jLoader:
                 UNWIND $rows AS r
                 MERGE (n:Function {id: r.id})
                 SET n.name = r.name, n.file = r.file,
-                    n.is_component = r.is_component, n.exported = r.exported
+                    n.is_component = r.is_component, n.exported = r.exported,
+                    n.docstring = r.docstring, n.return_type = r.return_type,
+                    n.params_json = r.params_json
                 WITH n, r
                 MATCH (f:File {path: r.file})
                 MERGE (f)-[:DEFINES_FUNC]->(n)
             """, [
                 dict(id=f.id, name=f.name, file=f.file,
-                     is_component=f.is_component, exported=f.exported)
+                     is_component=f.is_component, exported=f.exported,
+                     docstring=f.docstring, return_type=f.return_type,
+                     params_json=f.params_json)
                 for f in funcs
             ])
             _run(s, "UNWIND $rows AS r MATCH (f:Function {id: r.id}) SET f:Component",
@@ -260,14 +264,19 @@ class Neo4jLoader:
                 SET n.name = r.name, n.file = r.file,
                     n.is_static = r.is_static, n.is_async = r.is_async,
                     n.is_constructor = r.is_constructor,
-                    n.visibility = r.visibility
+                    n.visibility = r.visibility,
+                    n.return_type = r.return_type,
+                    n.params_json = r.params_json,
+                    n.docstring = r.docstring
                 WITH n, r
                 MATCH (c:Class {id: r.class_id})
                 MERGE (c)-[:HAS_METHOD]->(n)
             """, [
                 dict(id=m.id, name=m.name, file=m.file, class_id=m.class_id,
                      is_static=m.is_static, is_async=m.is_async,
-                     is_constructor=m.is_constructor, visibility=m.visibility)
+                     is_constructor=m.is_constructor, visibility=m.visibility,
+                     return_type=m.return_type, params_json=m.params_json,
+                     docstring=m.docstring)
                 for m in methods
             ])
 

--- a/codegraph/codegraph/loader.py
+++ b/codegraph/codegraph/loader.py
@@ -8,6 +8,7 @@ from neo4j import Driver, GraphDatabase
 
 from .resolver import Index
 from .schema import (
+    BELONGS_TO,
     CALLS,
     CALLS_ENDPOINT,
     CONTRIBUTED_BY,
@@ -34,6 +35,7 @@ from .schema import (
     INJECTS,
     LAST_MODIFIED_BY,
     OWNED_BY,
+    PackageNode,
     PROVIDES,
     READS_ATOM,
     READS_ENV,
@@ -72,6 +74,7 @@ _CONSTRAINTS = [
     "CREATE CONSTRAINT author_email IF NOT EXISTS FOR (n:Author) REQUIRE n.email IS UNIQUE",
     "CREATE CONSTRAINT team_name IF NOT EXISTS FOR (n:Team) REQUIRE n.name IS UNIQUE",
     "CREATE CONSTRAINT route_id IF NOT EXISTS FOR (n:Route) REQUIRE n.id IS UNIQUE",
+    "CREATE CONSTRAINT package_name IF NOT EXISTS FOR (n:Package) REQUIRE n.name IS UNIQUE",
 ]
 
 _INDEXES = [
@@ -97,6 +100,8 @@ class LoadStats:
     columns: int = 0
     gql_operations: int = 0
     atoms: int = 0
+    packages: int = 0
+    belongs_to_edges: int = 0
     edges: dict = field(default_factory=dict)
 
 
@@ -191,6 +196,10 @@ class Neo4jLoader:
                 MATCH (f:File {path: r.path})
                 SET f:TestFile
             """, [dict(path=f.path) for f in files if f.is_test])
+
+            # ── Packages + BELONGS_TO edges ───────────────────────
+            _write_packages(s, index.packages, stats)
+            _write_belongs_to(s, files, stats)
 
             # ── Classes ───────────────────────────────────────────
             _run(s, """
@@ -363,6 +372,63 @@ def _run(session, cypher: str, rows: list) -> None:
     for i in range(0, len(rows), BATCH):
         chunk = rows[i:i + BATCH]
         session.run(cypher, rows=chunk)
+
+
+def _write_packages(session, packages: list[PackageNode], stats: LoadStats) -> None:
+    """MERGE one ``:Package`` node per configured monorepo package.
+
+    All :class:`~.framework.FrameworkInfo` fields are flattened onto the node
+    so queries can branch by stack in a single hop. The ``name`` is the unique
+    key and matches the ``package`` string property on every :class:`FileNode`.
+    """
+    rows = [
+        dict(
+            name=p.name,
+            framework=p.framework,
+            framework_version=p.framework_version,
+            typescript=p.typescript,
+            styling=p.styling,
+            router=p.router,
+            state_management=p.state_management,
+            ui_library=p.ui_library,
+            build_tool=p.build_tool,
+            package_manager=p.package_manager,
+            confidence=p.confidence,
+        )
+        for p in packages
+    ]
+    _run(session, """
+        UNWIND $rows AS r
+        MERGE (p:Package {name: r.name})
+        SET p.framework         = r.framework,
+            p.framework_version = r.framework_version,
+            p.typescript        = r.typescript,
+            p.styling           = r.styling,
+            p.router            = r.router,
+            p.state_management  = r.state_management,
+            p.ui_library        = r.ui_library,
+            p.build_tool        = r.build_tool,
+            p.package_manager   = r.package_manager,
+            p.confidence        = r.confidence
+    """, rows)
+    stats.packages = len(rows)
+
+
+def _write_belongs_to(session, files, stats: LoadStats) -> None:
+    """MERGE ``(f:File)-[:BELONGS_TO]->(p:Package)`` for every file.
+
+    The edge is redundant with :attr:`FileNode.package` (which stays for the
+    existing ``file_package`` index) but makes Cypher patterns one hop cleaner,
+    e.g. ``MATCH (f:File)-[:BELONGS_TO]->(p:Package {framework:'Next.js'})``.
+    """
+    rows = [dict(path=f.path, package=f.package) for f in files if f.package]
+    _run(session, """
+        UNWIND $rows AS r
+        MATCH (f:File {path: r.path})
+        MATCH (p:Package {name: r.package})
+        MERGE (f)-[:BELONGS_TO]->(p)
+    """, rows)
+    stats.belongs_to_edges = len(rows)
 
 
 def _write_edges(session, edges: list[Edge], stats: LoadStats) -> None:

--- a/codegraph/codegraph/loader.py
+++ b/codegraph/codegraph/loader.py
@@ -38,16 +38,19 @@ from .schema import (
     OWNED_BY,
     PackageNode,
     PROVIDES,
+    PY_CONFTEST_FILENAME,
+    PY_TEST_PREFIX,
+    PY_TEST_SUFFIX_TRAILING,
     READS_ATOM,
     READS_ENV,
     RELATES_TO,
     RENDERS,
-    RENDERS_COMPONENT,
     REPOSITORY_OF,
     RESOLVES,
     RETURNS,
     TESTS,
     TESTS_CLASS,
+    TS_TEST_SUFFIXES,
     USES_HOOK,
     USES_OPERATION,
     WRITES_ATOM,
@@ -752,7 +755,15 @@ def _write_per_file_extras(session, index: Index, stats: LoadStats) -> None:
 
 
 def _write_test_edges(session, index: Index, stats: LoadStats) -> None:
-    """Link *.spec.ts / *.test.ts to their production peer by filename."""
+    """Link test files to their production peer by filename.
+
+    TS: ``foo.spec.ts`` / ``foo.test.tsx`` → ``foo.ts`` / ``foo.tsx`` (same dir).
+    Python: ``test_foo.py`` / ``foo_test.py`` → ``foo.py`` (same dir only —
+    cross-directory pairing is ambiguous, deferred to Stage 2). ``conftest.py``
+    never pairs.
+    """
+    import posixpath
+
     rows: list = []
     rows_class: list = []
     files = index.files_by_path
@@ -760,17 +771,32 @@ def _write_test_edges(session, index: Index, stats: LoadStats) -> None:
     for rel, r in files.items():
         if not r.file.is_test:
             continue
-        # Derive peer: foo.spec.ts -> foo.ts
         peer = None
-        for suf in (".spec.ts", ".spec.tsx", ".test.ts", ".test.tsx"):
-            if rel.endswith(suf):
-                base = rel[: -len(suf)]
-                for ext in (".ts", ".tsx"):
-                    cand = base + ext
-                    if cand in files:
-                        peer = cand
-                        break
-                break
+
+        # TS pairing
+        if rel.endswith(TS_TEST_SUFFIXES):
+            for suf in TS_TEST_SUFFIXES:
+                if rel.endswith(suf):
+                    base = rel[: -len(suf)]
+                    for ext in (".ts", ".tsx"):
+                        cand = base + ext
+                        if cand in files:
+                            peer = cand
+                            break
+                    break
+        # Python pairing — same directory only
+        elif rel.endswith(".py"):
+            dirpath, basename = posixpath.split(rel)
+            if basename == PY_CONFTEST_FILENAME:
+                continue
+            cand = None
+            if basename.endswith(PY_TEST_SUFFIX_TRAILING):
+                cand = posixpath.join(dirpath, basename[: -len(PY_TEST_SUFFIX_TRAILING)] + ".py")
+            elif basename.startswith(PY_TEST_PREFIX):
+                cand = posixpath.join(dirpath, basename[len(PY_TEST_PREFIX):])
+            if cand and cand in files:
+                peer = cand
+
         if peer:
             rows.append(dict(test=rel, peer=peer))
         # Also link by described subject

--- a/codegraph/codegraph/mcp.py
+++ b/codegraph/codegraph/mcp.py
@@ -36,7 +36,7 @@ import os
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
-from neo4j import READ_ACCESS, GraphDatabase
+from neo4j import READ_ACCESS, Driver, GraphDatabase
 from neo4j.exceptions import ClientError, CypherSyntaxError, ServiceUnavailable
 
 from .utils.neo4j_json import clean_row
@@ -51,15 +51,25 @@ _PASS = os.environ.get("CODEGRAPH_NEO4J_PASS", "codegraph123")
 
 # ── Driver lifecycle ────────────────────────────────────────────────
 
-_driver = GraphDatabase.driver(_URI, auth=(_USER, _PASS))
-"""Module-scoped Neo4j driver. One driver, many sessions — mirrors the
-:class:`codegraph.loader.Neo4jLoader` pattern. Tests monkeypatch this
-attribute directly."""
+_driver: "Driver | None" = None
+"""Module-scoped Neo4j driver. Lazily constructed on first tool call so that
+``import codegraph.mcp`` can succeed even when Neo4j is unreachable or the
+env vars are mis-set — the error surfaces as a tool-call error instead of
+an import-time traceback that kills the MCP server before Claude Code can
+see it. Tests monkeypatch this attribute with a fake driver directly."""
+
+
+def _get_driver() -> "Driver":
+    """Return the module-scoped driver, constructing it on first use."""
+    global _driver
+    if _driver is None:
+        _driver = GraphDatabase.driver(_URI, auth=(_USER, _PASS))
+    return _driver
 
 
 def _read_session():
     """Open a read-only session via the module-scoped driver."""
-    return _driver.session(default_access_mode=READ_ACCESS)
+    return _get_driver().session(default_access_mode=READ_ACCESS)
 
 
 def _err_msg(e: BaseException) -> str:
@@ -154,9 +164,9 @@ def describe_schema() -> dict:
                 "MATCH (n) RETURN labels(n)[0] AS label, count(*) AS n"
             ))
     except ClientError as e:
-        return {"error": f"Neo4j rejected query: {e.message}"}
+        return {"error": f"Neo4j rejected query: {_err_msg(e)}"}
     except ServiceUnavailable as e:
-        return {"error": f"Neo4j is unreachable: {e}"}
+        return {"error": f"Neo4j is unreachable: {_err_msg(e)}"}
     counts = {r["label"]: r["n"] for r in count_rows if r["label"]}
     return {"labels": labels, "rel_types": rel_types, "counts": counts}
 
@@ -227,8 +237,9 @@ def endpoints_for_controller(controller_name: str) -> list[dict]:
 # ── Entry point ─────────────────────────────────────────────────────
 
 def main() -> None:
-    """Run the stdio MCP server. Closes the driver on exit."""
+    """Run the stdio MCP server. Closes the driver on exit (if constructed)."""
     try:
         mcp.run(transport="stdio")
     finally:
-        _driver.close()
+        if _driver is not None:
+            _driver.close()

--- a/codegraph/codegraph/mcp.py
+++ b/codegraph/codegraph/mcp.py
@@ -410,6 +410,78 @@ def find_class(name_pattern: str, limit: int = 50) -> list[dict]:
 
 
 @mcp.tool()
+def calls_from(
+    name: str,
+    file: Optional[str] = None,
+    max_depth: int = 1,
+    limit: int = 50,
+) -> list[dict]:
+    """Return what a function/method calls, optionally transitively.
+
+    Walks outgoing ``:CALLS`` edges from every ``:Function`` / ``:Method`` node
+    whose ``name`` matches. Targets can be functions, methods, or ``:External``
+    nodes (unresolved calls — stdlib, builtins, dynamic). Use ``file`` to
+    disambiguate collisions across modules.
+
+    Args:
+        name: Exact ``:Function.name`` or ``:Method.name`` to traverse from.
+        file: Optional exact file path to narrow the source node.
+        max_depth: 1 for direct calls, up to 5 for transitive reach.
+        limit: Max rows to return. Integer in 1..1000, default 50.
+    """
+    if not isinstance(max_depth, int) or not 1 <= max_depth <= 5:
+        return [{"error": "max_depth must be an integer in 1..5"}]
+    err = _validate_limit(limit)
+    if err:
+        return [{"error": err}]
+    cypher = (
+        "MATCH (src) WHERE (src:Function OR src:Method) AND src.name = $name "
+        "  AND ($file IS NULL OR src.file = $file) "
+        f"MATCH (src)-[:CALLS*1..{max_depth}]->(dst) "
+        "RETURN DISTINCT labels(dst)[0] AS kind, dst.name AS name, "
+        "       coalesce(dst.file, '') AS file, "
+        "       coalesce(dst.docstring, '') AS docstring "
+        f"ORDER BY file, name LIMIT {limit}"
+    )
+    return _run_read(cypher, name=name, file=file)
+
+
+@mcp.tool()
+def callers_of(
+    name: str,
+    file: Optional[str] = None,
+    max_depth: int = 1,
+    limit: int = 50,
+) -> list[dict]:
+    """Return who calls a function/method, optionally transitively.
+
+    Walks incoming ``:CALLS`` edges in reverse to the named target. Callers
+    are always ``:Function`` or ``:Method`` — only those emit calls. Use
+    ``file`` to disambiguate collisions.
+
+    Args:
+        name: Exact ``:Function.name`` or ``:Method.name`` to find callers of.
+        file: Optional exact file path to narrow the target node.
+        max_depth: 1 for direct callers, up to 5 for transitive reach.
+        limit: Max rows to return. Integer in 1..1000, default 50.
+    """
+    if not isinstance(max_depth, int) or not 1 <= max_depth <= 5:
+        return [{"error": "max_depth must be an integer in 1..5"}]
+    err = _validate_limit(limit)
+    if err:
+        return [{"error": err}]
+    cypher = (
+        "MATCH (dst) WHERE (dst:Function OR dst:Method) AND dst.name = $name "
+        "  AND ($file IS NULL OR dst.file = $file) "
+        f"MATCH (src)-[:CALLS*1..{max_depth}]->(dst) "
+        "WHERE src:Function OR src:Method "
+        "RETURN DISTINCT labels(src)[0] AS kind, src.name AS name, src.file AS file "
+        f"ORDER BY src.file, src.name LIMIT {limit}"
+    )
+    return _run_read(cypher, name=name, file=file)
+
+
+@mcp.tool()
 def describe_function(name: str, file: Optional[str] = None) -> list[dict]:
     """Return rich signature info for functions and methods matching ``name``.
 

--- a/codegraph/codegraph/mcp.py
+++ b/codegraph/codegraph/mcp.py
@@ -1,0 +1,234 @@
+"""Stdio MCP server exposing the codegraph Neo4j graph to LLM coding agents.
+
+Registered as a console script via ``pyproject.toml``::
+
+    [project.scripts]
+    codegraph-mcp = "codegraph.mcp:main"
+
+Install with::
+
+    pip install "codegraph[mcp]"
+
+Then add to ``~/.claude.json``::
+
+    {
+      "mcpServers": {
+        "codegraph": {
+          "command": "codegraph-mcp",
+          "type": "stdio",
+          "env": {
+            "CODEGRAPH_NEO4J_URI":  "bolt://localhost:7688",
+            "CODEGRAPH_NEO4J_USER": "neo4j",
+            "CODEGRAPH_NEO4J_PASS": "codegraph123"
+          }
+        }
+      }
+    }
+
+All tools are read-only: every session is opened with
+``default_access_mode=neo4j.READ_ACCESS`` so an LLM-generated ``DROP`` or
+``DELETE`` query will surface as a Neo4j ``ClientError`` rather than mutating
+the graph.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+from neo4j import READ_ACCESS, GraphDatabase
+from neo4j.exceptions import ClientError, CypherSyntaxError, ServiceUnavailable
+
+from .utils.neo4j_json import clean_row
+
+
+# ── Configuration ───────────────────────────────────────────────────
+
+_URI = os.environ.get("CODEGRAPH_NEO4J_URI", "bolt://localhost:7688")
+_USER = os.environ.get("CODEGRAPH_NEO4J_USER", "neo4j")
+_PASS = os.environ.get("CODEGRAPH_NEO4J_PASS", "codegraph123")
+
+
+# ── Driver lifecycle ────────────────────────────────────────────────
+
+_driver = GraphDatabase.driver(_URI, auth=(_USER, _PASS))
+"""Module-scoped Neo4j driver. One driver, many sessions — mirrors the
+:class:`codegraph.loader.Neo4jLoader` pattern. Tests monkeypatch this
+attribute directly."""
+
+
+def _read_session():
+    """Open a read-only session via the module-scoped driver."""
+    return _driver.session(default_access_mode=READ_ACCESS)
+
+
+def _err_msg(e: BaseException) -> str:
+    """Extract a human-readable message from a Neo4j exception.
+
+    ``Neo4jError.message`` is the preferred field but is only populated when
+    the driver constructs the exception via its internal factory. When an
+    exception is built ad-hoc (e.g. in tests) ``message`` is ``None``, so
+    fall back to ``str(e)``.
+    """
+    msg = getattr(e, "message", None)
+    return msg if msg else str(e)
+
+
+def _run_read(cypher: str, **params: Any) -> list[dict]:
+    """Execute a read-only Cypher query and return JSON-clean rows.
+
+    Catches every Neo4j exception we know how to recover from and returns
+    ``[{"error": "..."}]`` so the calling agent can reason about the failure
+    instead of having the MCP client surface a tool-call error.
+    """
+    try:
+        with _read_session() as s:
+            records = list(s.run(cypher, **params))
+    except CypherSyntaxError as e:
+        return [{"error": f"Cypher syntax error: {_err_msg(e)}"}]
+    except ClientError as e:
+        return [{"error": f"Neo4j rejected query: {_err_msg(e)}"}]
+    except ServiceUnavailable as e:
+        return [{"error": f"Neo4j is unreachable: {e}"}]
+    return [clean_row(r) for r in records]
+
+
+# ── FastMCP server + tools ──────────────────────────────────────────
+
+mcp = FastMCP("codegraph")
+
+
+@mcp.tool()
+def query_graph(cypher: str, limit: int = 20) -> list[dict]:
+    """Run a read-only Cypher query against the codegraph Neo4j database.
+
+    Writes (CREATE/MERGE/DELETE/SET) are rejected by the server because the
+    underlying session is read-only. Returns up to ``limit`` rows, each a flat
+    dict of column → JSON-safe value. Neo4j ``Node`` / ``Relationship`` values
+    are unwrapped to their property dict.
+
+    Args:
+        cypher: Cypher query string. Example:
+            ``MATCH (c:Class {is_controller:true}) RETURN c.name LIMIT 10``
+        limit: Maximum rows to return (default 20, cap 1000).
+    """
+    if not isinstance(limit, int) or limit < 1:
+        return [{"error": "limit must be a positive integer"}]
+    limit = min(limit, 1000)
+    try:
+        with _read_session() as s:
+            records = list(s.run(cypher))[:limit]
+    except CypherSyntaxError as e:
+        return [{"error": f"Cypher syntax error: {_err_msg(e)}"}]
+    except ClientError as e:
+        return [{"error": f"Neo4j rejected query: {_err_msg(e)}"}]
+    except ServiceUnavailable as e:
+        return [{"error": f"Neo4j is unreachable: {e}"}]
+    return [clean_row(r) for r in records]
+
+
+@mcp.tool()
+def describe_schema() -> dict:
+    """Return labels, relationship types, and node counts per label.
+
+    Agents should call this once at session start to learn what's in the graph
+    instead of guessing from documentation. Shape:
+
+        {
+          "labels":    ["File", "Class", "Function", ...],
+          "rel_types": ["IMPORTS", "DEFINES_CLASS", ...],
+          "counts":    {"File": 1234, "Class": 567, ...},
+        }
+    """
+    try:
+        with _read_session() as s:
+            labels = [r["label"] for r in s.run("CALL db.labels() YIELD label RETURN label ORDER BY label")]
+            rel_types = [
+                r["relationshipType"]
+                for r in s.run(
+                    "CALL db.relationshipTypes() YIELD relationshipType "
+                    "RETURN relationshipType ORDER BY relationshipType"
+                )
+            ]
+            count_rows = list(s.run(
+                "MATCH (n) RETURN labels(n)[0] AS label, count(*) AS n"
+            ))
+    except ClientError as e:
+        return {"error": f"Neo4j rejected query: {e.message}"}
+    except ServiceUnavailable as e:
+        return {"error": f"Neo4j is unreachable: {e}"}
+    counts = {r["label"]: r["n"] for r in count_rows if r["label"]}
+    return {"labels": labels, "rel_types": rel_types, "counts": counts}
+
+
+@mcp.tool()
+def list_packages() -> list[dict]:
+    """Return every indexed monorepo package with its detected framework.
+
+    Fields: ``name``, ``framework``, ``framework_version``, ``typescript``,
+    ``package_manager``, ``confidence``. Ordered by package name. Empty list
+    if no packages have been detected yet (run ``codegraph index`` first).
+    """
+    return _run_read(
+        "MATCH (p:Package) "
+        "RETURN p.name AS name, p.framework AS framework, "
+        "       p.framework_version AS framework_version, "
+        "       p.typescript AS typescript, "
+        "       p.package_manager AS package_manager, "
+        "       p.confidence AS confidence "
+        "ORDER BY p.name"
+    )
+
+
+@mcp.tool()
+def callers_of_class(class_name: str, max_depth: int = 3) -> list[dict]:
+    """Blast-radius traversal: who reaches the given class transitively?
+
+    Walks ``INJECTS`` / ``EXTENDS`` / ``IMPLEMENTS`` edges in reverse from the
+    target class up to ``max_depth`` hops. Returns distinct caller classes
+    with their file and backend-role flags.
+
+    Args:
+        class_name: Exact ``:Class.name`` to query (e.g. ``"AuthService"``).
+        max_depth: Max hops to traverse (1..10, default 3).
+    """
+    if not isinstance(max_depth, int) or not 1 <= max_depth <= 10:
+        return [{"error": "max_depth must be an integer in 1..10"}]
+    # Variable-length path bounds cannot be bind parameters in Cypher; the
+    # integer is validated above before we interpolate it.
+    cypher = (
+        f"MATCH (caller:Class)-[:INJECTS|EXTENDS|IMPLEMENTS*1..{max_depth}]->"
+        "(target:Class {name: $class_name}) "
+        "RETURN DISTINCT caller.name AS name, caller.file AS file, "
+        "       caller.is_injectable AS is_injectable, "
+        "       caller.is_controller AS is_controller "
+        "ORDER BY caller.name"
+    )
+    return _run_read(cypher, class_name=class_name)
+
+
+@mcp.tool()
+def endpoints_for_controller(controller_name: str) -> list[dict]:
+    """Return the HTTP endpoints exposed by a NestJS controller class.
+
+    Args:
+        controller_name: Exact ``:Class.name`` of the controller
+            (e.g. ``"UserController"``). Must have ``is_controller=true``.
+    """
+    return _run_read(
+        "MATCH (c:Class {name: $controller_name, is_controller: true})"
+        "-[:EXPOSES]->(e:Endpoint) "
+        "RETURN e.method AS method, e.path AS path, e.handler AS handler "
+        "ORDER BY e.path",
+        controller_name=controller_name,
+    )
+
+
+# ── Entry point ─────────────────────────────────────────────────────
+
+def main() -> None:
+    """Run the stdio MCP server. Closes the driver on exit."""
+    try:
+        mcp.run(transport="stdio")
+    finally:
+        _driver.close()

--- a/codegraph/codegraph/mcp.py
+++ b/codegraph/codegraph/mcp.py
@@ -301,7 +301,10 @@ def hook_usage(hook_name: str, limit: int = 50) -> list[dict]:
     cypher = (
         "MATCH (fn:Function)-[:USES_HOOK]->(:Hook {name: $hook_name}) "
         "RETURN DISTINCT fn.name AS name, fn.file AS file, "
-        "       fn.is_component AS is_component "
+        "       fn.is_component AS is_component, "
+        "       fn.docstring AS docstring, "
+        "       fn.params_json AS params_json, "
+        "       fn.return_type AS return_type "
         f"ORDER BY fn.name LIMIT {limit}"
     )
     return _run_read(cypher, hook_name=hook_name)
@@ -344,6 +347,8 @@ def gql_operation_callers(
         "WHERE $op_type IS NULL OR op.type = $op_type "
         "RETURN DISTINCT caller.name AS caller_name, caller.file AS caller_file, "
         "       labels(caller)[0] AS caller_kind, "
+        "       caller.docstring AS caller_docstring, "
+        "       caller.params_json AS caller_params_json, "
         "       op.type AS op_type, op.return_type AS return_type "
         f"ORDER BY caller.name LIMIT {limit}"
     )
@@ -402,6 +407,34 @@ def find_class(name_pattern: str, limit: int = 50) -> list[dict]:
         f"ORDER BY c.name LIMIT {limit}"
     )
     return _run_read(cypher, name_pattern=name_pattern)
+
+
+@mcp.tool()
+def describe_function(name: str, file: Optional[str] = None) -> list[dict]:
+    """Return rich signature info for functions and methods matching ``name``.
+
+    Projects ``docstring``, ``params_json``, ``return_type`` and the list of
+    decorator names so an agent can answer "what does X do" in one tool call
+    instead of reading the source. Matches both ``:Function`` and ``:Method``
+    nodes. The same name may exist in several files — pass ``file`` to
+    narrow, otherwise every match is returned.
+
+    Args:
+        name: Exact ``:Function.name`` or ``:Method.name``.
+        file: Optional exact file path (``:File.path``) to disambiguate
+            collisions across modules.
+    """
+    cypher = (
+        "MATCH (n) WHERE (n:Function OR n:Method) AND n.name = $name "
+        "  AND ($file IS NULL OR n.file = $file) "
+        "OPTIONAL MATCH (n)-[:DECORATED_BY]->(d:Decorator) "
+        "WITH n, collect(DISTINCT d.name) AS decorators "
+        "RETURN labels(n)[0] AS kind, n.name AS name, n.file AS file, "
+        "       n.docstring AS docstring, n.params_json AS params_json, "
+        "       n.return_type AS return_type, decorators "
+        "ORDER BY n.file, n.name"
+    )
+    return _run_read(cypher, name=name, file=file)
 
 
 # ── Entry point ─────────────────────────────────────────────────────

--- a/codegraph/codegraph/mcp.py
+++ b/codegraph/codegraph/mcp.py
@@ -33,7 +33,7 @@ the graph.
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, Optional
 
 from mcp.server.fastmcp import FastMCP
 from neo4j import READ_ACCESS, Driver, GraphDatabase
@@ -82,6 +82,23 @@ def _err_msg(e: BaseException) -> str:
     """
     msg = getattr(e, "message", None)
     return msg if msg else str(e)
+
+
+def _validate_limit(limit: int, *, max_limit: int = 1000) -> Optional[str]:
+    """Return an error message if ``limit`` is out of range, ``None`` if OK.
+
+    Limits must be interpolated into the Cypher string rather than passed as
+    a bind parameter — Neo4j 5.x rejects ``LIMIT $param`` as a syntax error,
+    so the only way to parameterise is to interpolate. Every caller must
+    validate through this helper before building the Cypher to close the
+    injection surface: if the agent passes a non-int, we reject cleanly
+    instead of letting it land as a format-string exception.
+    """
+    if not isinstance(limit, int) or isinstance(limit, bool):
+        return f"limit must be an integer in 1..{max_limit}"
+    if limit < 1 or limit > max_limit:
+        return f"limit must be an integer in 1..{max_limit}"
+    return None
 
 
 def _run_read(cypher: str, **params: Any) -> list[dict]:
@@ -232,6 +249,159 @@ def endpoints_for_controller(controller_name: str) -> list[dict]:
         "ORDER BY e.path",
         controller_name=controller_name,
     )
+
+
+@mcp.tool()
+def files_in_package(name: str, limit: int = 50) -> list[dict]:
+    """List files belonging to a monorepo package.
+
+    Uses the existing ``file_package`` property index directly rather than
+    hopping through ``:BELONGS_TO`` — faster, same result. Returns an empty
+    list for unknown package names (no error; the empty result *is* the
+    answer).
+
+    Args:
+        name: Exact ``:Package.name`` (equivalently ``:File.package``), e.g.
+            ``"twenty-server"`` or ``"packages/web"`` depending on how the
+            monorepo was configured.
+        limit: Max rows to return. Integer in 1..1000, default 50.
+    """
+    err = _validate_limit(limit)
+    if err:
+        return [{"error": err}]
+    cypher = (
+        "MATCH (f:File {package: $name}) "
+        "RETURN f.path AS path, f.language AS language, f.loc AS loc, "
+        "       f.is_controller AS is_controller, f.is_component AS is_component, "
+        "       f.is_injectable AS is_injectable, f.is_module AS is_module, "
+        "       f.is_entity AS is_entity "
+        f"ORDER BY f.path LIMIT {limit}"
+    )
+    return _run_read(cypher, name=name)
+
+
+@mcp.tool()
+def hook_usage(hook_name: str, limit: int = 50) -> list[dict]:
+    """Return the functions / components that use a given React hook.
+
+    Direction in the graph is ``(:Function)-[:USES_HOOK]->(:Hook)``.
+    ``fn.is_component`` is included so the agent can tell apart true React
+    components from helper functions that happen to live in the same file.
+
+    Args:
+        hook_name: Exact ``:Hook.name`` (e.g. ``"useAuth"``, ``"useDeepMemo"``).
+            Only custom hooks that codegraph detected are present as
+            ``:Hook`` nodes — built-in React hooks like ``useState`` are
+            imports, not nodes.
+        limit: Max rows to return. Integer in 1..1000, default 50.
+    """
+    err = _validate_limit(limit)
+    if err:
+        return [{"error": err}]
+    cypher = (
+        "MATCH (fn:Function)-[:USES_HOOK]->(:Hook {name: $hook_name}) "
+        "RETURN DISTINCT fn.name AS name, fn.file AS file, "
+        "       fn.is_component AS is_component "
+        f"ORDER BY fn.name LIMIT {limit}"
+    )
+    return _run_read(cypher, hook_name=hook_name)
+
+
+_GQL_OP_TYPES = ("query", "mutation", "subscription")
+
+
+@mcp.tool()
+def gql_operation_callers(
+    op_name: str,
+    op_type: Optional[str] = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Return callers of a GraphQL operation (query / mutation / subscription).
+
+    Direction in the graph is ``(caller)-[:USES_OPERATION]->(:GraphQLOperation)``.
+    ``op_name`` alone may match multiple operations if the same name exists
+    across query / mutation / subscription types — pass ``op_type`` to narrow.
+
+    ``labels(caller)[0]`` is returned as ``caller_kind`` so the agent can tell
+    apart ``Function`` / ``Method`` / ``Class`` callers without a second query.
+
+    Args:
+        op_name: Exact ``:GraphQLOperation.name``, e.g. ``"findManyUsers"``.
+        op_type: Optional filter, one of ``"query"``, ``"mutation"``,
+            ``"subscription"``. ``None`` (default) returns callers across all
+            three types.
+        limit: Max rows to return. Integer in 1..1000, default 50.
+    """
+    err = _validate_limit(limit)
+    if err:
+        return [{"error": err}]
+    if op_type is not None and op_type not in _GQL_OP_TYPES:
+        return [{
+            "error": "op_type must be one of 'query' | 'mutation' | 'subscription'"
+        }]
+    cypher = (
+        "MATCH (caller)-[:USES_OPERATION]->(op:GraphQLOperation {name: $op_name}) "
+        "WHERE $op_type IS NULL OR op.type = $op_type "
+        "RETURN DISTINCT caller.name AS caller_name, caller.file AS caller_file, "
+        "       labels(caller)[0] AS caller_kind, "
+        "       op.type AS op_type, op.return_type AS return_type "
+        f"ORDER BY caller.name LIMIT {limit}"
+    )
+    return _run_read(cypher, op_name=op_name, op_type=op_type)
+
+
+@mcp.tool()
+def most_injected_services(limit: int = 20) -> list[dict]:
+    """Rank ``@Injectable`` classes by number of unique callers.
+
+    The canonical "DI hub detection" query advertised on the codegraph README
+    front page. Counts distinct caller classes (not raw edges) so a caller
+    injecting the same service into multiple methods still counts once.
+
+    Args:
+        limit: Max rows to return. Integer in 1..100, default 20. Tighter
+            cap than the other tools — nobody wants 1000 hubs.
+    """
+    err = _validate_limit(limit, max_limit=100)
+    if err:
+        return [{"error": err}]
+    cypher = (
+        "MATCH (svc:Class {is_injectable: true})<-[:INJECTS]-(caller:Class) "
+        "RETURN svc.name AS name, svc.file AS file, "
+        "       count(DISTINCT caller) AS injections, "
+        "       svc.is_controller AS is_controller "
+        f"ORDER BY injections DESC LIMIT {limit}"
+    )
+    return _run_read(cypher)
+
+
+@mcp.tool()
+def find_class(name_pattern: str, limit: int = 50) -> list[dict]:
+    """Case-sensitive substring search over class names.
+
+    Backed by the ``class_name`` index so ``CONTAINS`` stays cheap. Bypassing
+    the index via ``toLower()`` for case-insensitive matching would turn this
+    into a full scan; agents can retry with the correct case instead.
+
+    Args:
+        name_pattern: Non-empty substring to match against ``:Class.name``.
+            Empty strings are rejected — they'd match every class in the graph.
+        limit: Max rows to return. Integer in 1..1000, default 50.
+    """
+    if not name_pattern:
+        return [{"error": "name_pattern must be non-empty"}]
+    err = _validate_limit(limit)
+    if err:
+        return [{"error": err}]
+    cypher = (
+        "MATCH (c:Class) WHERE c.name CONTAINS $name_pattern "
+        "RETURN c.name AS name, c.file AS file, "
+        "       c.is_controller AS is_controller, c.is_injectable AS is_injectable, "
+        "       c.is_module AS is_module, c.is_entity AS is_entity, "
+        "       c.is_resolver AS is_resolver "
+        f"ORDER BY c.name LIMIT {limit}"
+    )
+    return _run_read(cypher, name_pattern=name_pattern)
 
 
 # ── Entry point ─────────────────────────────────────────────────────

--- a/codegraph/codegraph/ownership.py
+++ b/codegraph/codegraph/ownership.py
@@ -1,0 +1,127 @@
+"""Phase 7: git log + CODEOWNERS ingestion."""
+from __future__ import annotations
+
+import fnmatch
+import re
+import subprocess
+from collections import Counter
+from pathlib import Path
+from typing import Optional
+
+
+def collect_ownership(repo_root: Path, indexed_files: set[str]) -> dict:
+    """Build authors/teams/last_modified/contributors/owned_by from git + CODEOWNERS."""
+    authors: dict[str, dict] = {}
+    last_modified: list[dict] = []
+    contributors: list[dict] = []
+
+    # Single git log call: name + email + timestamp + file list per commit
+    try:
+        proc = subprocess.run(
+            ["git", "log", "--name-only", "--pretty=format:__COMMIT__%H|%ae|%an|%at"],
+            cwd=str(repo_root), capture_output=True, text=True, check=False, timeout=120,
+        )
+        log_text = proc.stdout
+    except (OSError, subprocess.SubprocessError):
+        return {}
+
+    file_last: dict[str, tuple[str, int]] = {}    # file -> (email, ts)
+    file_counts: dict[str, Counter] = {}          # file -> Counter[email]
+    current_email: Optional[str] = None
+    current_name: Optional[str] = None
+    current_ts: int = 0
+
+    for line in log_text.splitlines():
+        if line.startswith("__COMMIT__"):
+            try:
+                _, payload = line.split("__COMMIT__", 1)
+                _h, email, name, ts = payload.split("|", 3)
+                current_email = email
+                current_name = name
+                current_ts = int(ts)
+                if email not in authors:
+                    authors[email] = {"email": email, "name": name}
+            except ValueError:
+                current_email = None
+            continue
+        if not line.strip():
+            continue
+        if current_email is None:
+            continue
+        # File touched in this commit
+        f = line.strip()
+        if f not in indexed_files:
+            continue
+        # Last modified = first time we encounter a file (git log is newest-first)
+        if f not in file_last:
+            file_last[f] = (current_email, current_ts)
+        file_counts.setdefault(f, Counter())[current_email] += 1
+
+    for f, (email, ts) in file_last.items():
+        last_modified.append({"path": f, "email": email, "at": ts})
+    for f, counter in file_counts.items():
+        for email, count in counter.most_common(10):
+            contributors.append({"path": f, "email": email, "commits": count})
+
+    # CODEOWNERS
+    teams: set[str] = set()
+    owned_by: list[dict] = []
+    co_paths = [
+        repo_root / "CODEOWNERS",
+        repo_root / ".github" / "CODEOWNERS",
+        repo_root / "docs" / "CODEOWNERS",
+    ]
+    co_file = next((p for p in co_paths if p.exists()), None)
+    if co_file is not None:
+        rules = _parse_codeowners(co_file)
+        for f in indexed_files:
+            owners = _match_codeowners(f, rules)
+            for o in owners:
+                teams.add(o)
+                owned_by.append({"path": f, "team": o})
+
+    return {
+        "authors": list(authors.values()),
+        "teams": sorted(teams),
+        "last_modified": last_modified,
+        "contributors": contributors,
+        "owned_by": owned_by,
+    }
+
+
+_CO_LINE_RE = re.compile(r"^\s*([^\s#]+)\s+(.+)$")
+
+
+def _parse_codeowners(p: Path) -> list[tuple[str, list[str]]]:
+    rules: list[tuple[str, list[str]]] = []
+    for line in p.read_text(errors="replace").splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        m = _CO_LINE_RE.match(line)
+        if not m:
+            continue
+        pat = m.group(1)
+        owners = [t for t in m.group(2).split() if t.startswith("@")]
+        rules.append((pat, owners))
+    return rules
+
+
+def _match_codeowners(path: str, rules: list[tuple[str, list[str]]]) -> list[str]:
+    """Last matching rule wins (CODEOWNERS semantics)."""
+    matched: list[str] = []
+    for pat, owners in rules:
+        if _co_pattern_match(pat, path):
+            matched = owners
+    return matched
+
+
+def _co_pattern_match(pat: str, path: str) -> bool:
+    # /foo means rooted at repo root
+    if pat.startswith("/"):
+        pat = pat[1:]
+        return fnmatch.fnmatch(path, pat) or fnmatch.fnmatch(path, pat + "*")
+    # **/ pattern
+    if "/" not in pat.rstrip("*/"):
+        return any(fnmatch.fnmatch(seg, pat.rstrip("/")) for seg in path.split("/"))
+    return fnmatch.fnmatch(path, "*" + pat) or fnmatch.fnmatch(path, pat)

--- a/codegraph/codegraph/parser.py
+++ b/codegraph/codegraph/parser.py
@@ -55,6 +55,15 @@ _GQL_DECORATORS = {
     "ResolveField": "field",
 }
 
+# Class-level decorators that mark a class as a GraphQL resolver
+# (NestJS standard + Twenty conventions)
+_RESOLVER_CLASS_DECORATORS = {
+    "Resolver",
+    "MetadataResolver",
+    "CoreResolver",
+    "WorkspaceResolver",
+}
+
 _TYPEORM_COLUMN_DECORATORS = {
     "Column",
     "PrimaryColumn",
@@ -310,7 +319,7 @@ class _Walker:
                 cls.is_entity = True
                 if dargs:
                     cls.table_name = self._strip_quotes(dargs[0])
-            elif dname == "Resolver":
+            elif dname in _RESOLVER_CLASS_DECORATORS:
                 cls.is_resolver = True
 
         # Heritage
@@ -629,7 +638,11 @@ class _Walker:
             return
         field_name = self._text(name_node)
 
-        for dec in decorators:
+        # Field decorators live as children of the field node, not preceding siblings
+        own_decorators = [c for c in node.children if c.type == "decorator"]
+        all_decorators = decorators + own_decorators
+
+        for dec in all_decorators:
             dname, dargs, dargs_raw = self._parse_decorator(dec)
             if not dname:
                 continue
@@ -767,6 +780,10 @@ class _Walker:
             if value is None:
                 continue
 
+            # Top-level gql`...` literal bound to a const
+            if value.type in ("call_expression", "tagged_template_expression"):
+                self._scan_top_level_gql(value, name)
+
             # Function / component
             if value.type in ("arrow_function", "function_expression"):
                 fn = FunctionNode(name=name, file=self.result.file.path, exported=exported)
@@ -800,10 +817,75 @@ class _Walker:
                         Edge(kind=DEFINES_ATOM, src_id=self.result.file.id, dst_id=atom.id)
                     )
 
+    def _scan_top_level_gql(self, node: Node, binder: str) -> None:
+        """Detect `const X = gql`...`` at module scope."""
+        # tagged_template_expression: tag + template_string
+        if node.type == "tagged_template_expression":
+            tag = None
+            tmpl = None
+            for c in node.children:
+                if c.type in ("identifier", "member_expression"):
+                    tag = c
+                elif c.type == "template_string":
+                    tmpl = c
+            if tag is not None and tmpl is not None:
+                tag_name = self._text(tag)
+                if tag_name == "gql" or tag_name.endswith(".gql"):
+                    content = self._text(tmpl).strip("`")
+                    for m in _GQL_OP_RE.finditer(content):
+                        # Use the const binder name as the "containing function"
+                        self.result.gql_literals.append((binder, m.group(1), m.group(2)))
+            return
+
+        # call_expression: gql`...` (tree-sitter parses tagged-template as call_expression
+        # with the template_string as a direct child sibling of the function identifier)
+        if node.type == "call_expression":
+            fn_node = None
+            tmpl_node = None
+            for c in node.children:
+                if c.type in ("identifier", "member_expression") and fn_node is None:
+                    fn_node = c
+                elif c.type == "template_string":
+                    tmpl_node = c
+            if fn_node is None or tmpl_node is None:
+                return
+            tag = self._text(fn_node)
+            if tag != "gql" and not tag.endswith(".gql"):
+                return
+            content = self._text(tmpl_node).strip("`")
+            for m in _GQL_OP_RE.finditer(content):
+                self.result.gql_literals.append((binder, m.group(1), m.group(2)))
+
     def _scan_function_body(self, body: Node, fn: FunctionNode) -> None:
         """For component bodies: JSX renders, hook calls, atom reads, env reads, gql literals, REST calls."""
         for d in _descendants(body):
             t = d.type
+
+            # Nested atom definitions (Twenty wraps atoms in factory functions)
+            if t == "variable_declarator":
+                id_node = d.child_by_field_name("name")
+                if id_node is not None and id_node.type == "identifier":
+                    val = d.child_by_field_name("value")
+                    if val is not None and val.type == "call_expression":
+                        callee = val.child_by_field_name("function")
+                        if callee is not None:
+                            cname = self._text(callee)
+                            if cname in ("atom", "atomFamily", "atomWithStorage", "atomWithReset"):
+                                atom_name = self._text(id_node)
+                                self.result.atoms.append(AtomNode(
+                                    name=atom_name,
+                                    file=self.result.file.path,
+                                    family=(cname == "atomFamily"),
+                                ))
+
+            # All string literals: check if URL-like, register as rest_call
+            if t == "string":
+                for sc in d.children:
+                    if sc.type == "string_fragment":
+                        s = self._text(sc)
+                        if _looks_like_backend_url(s):
+                            self.result.rest_calls.append((fn.name, "", s))
+                        break
 
             if t in ("jsx_opening_element", "jsx_self_closing_element"):
                 tag = self._jsx_tag_name(d)
@@ -1009,3 +1091,15 @@ def _looks_like_url(s: str) -> bool:
     if s.startswith("http"):
         return True
     return False
+
+
+_BACKEND_URL_RE = re.compile(
+    r"^/(rest|api|auth|graphql|webhooks?|public-assets?|file|client-config|health|open-api|openapi)(/[\w\-:.{}/]*)?(?:\?.*)?$"
+)
+
+
+def _looks_like_backend_url(s: str) -> bool:
+    """Stricter than _looks_like_url — must look like a real backend route."""
+    if not s or len(s) < 2 or len(s) > 200:
+        return False
+    return bool(_BACKEND_URL_RE.match(s))

--- a/codegraph/codegraph/parser.py
+++ b/codegraph/codegraph/parser.py
@@ -88,7 +88,12 @@ _REST_METHOD_NAMES = {"get", "post", "put", "patch", "delete", "request", "fetch
 
 _URL_LIKE_RE = re.compile(r"^[/]?(rest|api|auth|graphql|webhooks|public)[/\w\-:.?=]*$|^/[a-zA-Z0-9_\-/:.]+$")
 
-_GQL_OP_RE = re.compile(r"\b(query|mutation|subscription)\s+([A-Z_][\w]*)\b")
+_GQL_OP_RE = re.compile(r"\b(query|mutation|subscription)\s+([A-Za-z_][\w]*)\b")
+# Field name inside the operation body — this is what matches a resolver method name.
+# `query EventLogs($x: Y) { eventLogs(input: $x) { ... } }` → field = 'eventLogs'
+_GQL_FIELD_RE = re.compile(
+    r"\b(query|mutation|subscription)\b[\s\S]*?\{\s*(\w+)",
+)
 
 
 # ── Public API ───────────────────────────────────────────────
@@ -169,9 +174,52 @@ class _Walker:
     def walk_program(self, root: Node) -> None:
         for child in root.children:
             self._handle_top_level(child)
+        # Whole-file URL scan (catches module-level strings, class method bodies, etc.)
+        self._scan_file_for_urls(root)
 
     def finalize(self) -> None:
         pass
+
+    def _scan_file_for_urls(self, root: Node) -> None:
+        """Walk every string literal in the file; if URL-like, attribute to enclosing fn/method."""
+        seen: set = set()
+        for d in _descendants(root):
+            if d.type != "string":
+                continue
+            for sc in d.children:
+                if sc.type != "string_fragment":
+                    continue
+                s = self._text(sc)
+                if not _looks_like_backend_url(s):
+                    break
+                key = (s, d.start_byte)
+                if key in seen:
+                    break
+                seen.add(key)
+                # Walk up to find the enclosing function/method/component
+                container = self._enclosing_container_name(d)
+                self.result.rest_calls.append((container, "", s))
+                break
+
+    def _enclosing_container_name(self, n: Node) -> str:
+        """Walk up until we hit a function/method/arrow/class declarator and return its name."""
+        cur = n.parent
+        while cur is not None:
+            t = cur.type
+            if t == "method_definition":
+                name = cur.child_by_field_name("name")
+                if name is not None:
+                    return self._text(name)
+            elif t == "function_declaration":
+                name = cur.child_by_field_name("name")
+                if name is not None:
+                    return self._text(name)
+            elif t == "variable_declarator":
+                name = cur.child_by_field_name("name")
+                if name is not None and name.type == "identifier":
+                    return self._text(name)
+            cur = cur.parent
+        return "<module>"
 
     def _handle_top_level(self, node: Node) -> None:
         t = node.type
@@ -818,30 +866,24 @@ class _Walker:
                     )
 
     def _scan_top_level_gql(self, node: Node, binder: str) -> None:
-        """Detect `const X = gql`...`` at module scope."""
-        # tagged_template_expression: tag + template_string
+        """Detect `const X = gql`...`` at module scope. Extract field name from body."""
+        tmpl_node = None
         if node.type == "tagged_template_expression":
-            tag = None
-            tmpl = None
+            for c in node.children:
+                if c.type == "template_string":
+                    tmpl_node = c
+                    break
+            tag_name = ""
             for c in node.children:
                 if c.type in ("identifier", "member_expression"):
-                    tag = c
-                elif c.type == "template_string":
-                    tmpl = c
-            if tag is not None and tmpl is not None:
-                tag_name = self._text(tag)
-                if tag_name == "gql" or tag_name.endswith(".gql"):
-                    content = self._text(tmpl).strip("`")
-                    for m in _GQL_OP_RE.finditer(content):
-                        # Use the const binder name as the "containing function"
-                        self.result.gql_literals.append((binder, m.group(1), m.group(2)))
-            return
-
-        # call_expression: gql`...` (tree-sitter parses tagged-template as call_expression
-        # with the template_string as a direct child sibling of the function identifier)
-        if node.type == "call_expression":
+                    tag_name = self._text(c)
+                    break
+            if tmpl_node is None:
+                return
+            if tag_name != "gql" and not tag_name.endswith(".gql"):
+                return
+        elif node.type == "call_expression":
             fn_node = None
-            tmpl_node = None
             for c in node.children:
                 if c.type in ("identifier", "member_expression") and fn_node is None:
                     fn_node = c
@@ -852,9 +894,23 @@ class _Walker:
             tag = self._text(fn_node)
             if tag != "gql" and not tag.endswith(".gql"):
                 return
-            content = self._text(tmpl_node).strip("`")
-            for m in _GQL_OP_RE.finditer(content):
-                self.result.gql_literals.append((binder, m.group(1), m.group(2)))
+        else:
+            return
+
+        content = self._text(tmpl_node).strip("`")
+        self._emit_gql_operations(content, binder)
+
+    def _emit_gql_operations(self, content: str, binder: str) -> None:
+        """Extract op_type + field name from a gql document body."""
+        # Get document operation type from the FIRST keyword
+        m_op = _GQL_OP_RE.search(content)
+        op_type = m_op.group(1) if m_op else "query"
+        # Field names: every '{ <field>' in the document — but we want the top-level field
+        # which is the first identifier after the operation's outer body open brace
+        m_field = _GQL_FIELD_RE.search(content)
+        if m_field:
+            field_name = m_field.group(2)
+            self.result.gql_literals.append((binder, op_type, field_name))
 
     def _scan_function_body(self, body: Node, fn: FunctionNode) -> None:
         """For component bodies: JSX renders, hook calls, atom reads, env reads, gql literals, REST calls."""
@@ -943,10 +999,7 @@ class _Walker:
                         tag_name = self._text(tag_fn)
                         if tag_name.endswith("gql") or tag_name == "gql":
                             content = self._text(d).strip("`")
-                            for m in _GQL_OP_RE.finditer(content):
-                                self.result.gql_literals.append(
-                                    (fn.name, m.group(1), m.group(2))
-                                )
+                            self._emit_gql_operations(content, fn.name)
 
             elif t == "member_expression":
                 # process.env.X

--- a/codegraph/codegraph/py_parser.py
+++ b/codegraph/codegraph/py_parser.py
@@ -30,8 +30,10 @@ dispatch by file extension without special-casing downstream code.
 """
 from __future__ import annotations
 
+import json
+import textwrap
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 try:
     from tree_sitter import Language, Parser
@@ -365,8 +367,9 @@ class _PyWalker:
             is_async=False,
             is_constructor=is_constructor,
             visibility=visibility,
-            return_type="",
-            params_json="[]",
+            return_type=self._extract_return_type(node),
+            params_json=self._extract_params_json(node),
+            docstring=self._extract_docstring(node),
         )
         self.result.methods.append(method)
 
@@ -400,6 +403,9 @@ class _PyWalker:
             file=rel,
             is_component=False,  # never — that flag is TS/React-specific
             exported=True,       # Python has no `export`; module-level = importable
+            docstring=self._extract_docstring(node),
+            return_type=self._extract_return_type(node),
+            params_json=self._extract_params_json(node),
         )
         self.result.functions.append(fn)
 
@@ -419,6 +425,102 @@ class _PyWalker:
                     src_id=fn.id,
                     dst_id=f"dec:{dname}",
                 ))
+
+    # ── signature + docstring extraction ──────────────────────────────
+
+    def _extract_docstring(self, fn_def_node) -> str:
+        """Return the PEP 257 docstring of a function/method, or ``""``.
+
+        Docstring is the first statement of the body when that statement is
+        a bare string literal. We dedent per ``textwrap.dedent`` and strip
+        the surrounding quotes + string prefix so downstream consumers get
+        readable prose, not raw source. Comments between ``def`` and the
+        docstring are skipped; anything else as the first statement means
+        no docstring.
+        """
+        body = self._child_by_field(fn_def_node, "body")
+        if body is None:
+            return ""
+        first_stmt = None
+        for c in body.children:
+            if c.type == "comment":
+                continue
+            first_stmt = c
+            break
+        if first_stmt is None or first_stmt.type != "expression_statement":
+            return ""
+        for c in first_stmt.children:
+            if c.type == "string":
+                return self._clean_docstring(self._text(c))
+        return ""
+
+    def _clean_docstring(self, raw: str) -> str:
+        s = raw.strip()
+        # Drop prefix chars (r, b, u, f — docstrings rarely prefixed but be safe)
+        i = 0
+        while i < len(s) and s[i].lower() in "rbuf":
+            i += 1
+        s = s[i:]
+        for q in ('"""', "'''", '"', "'"):
+            if s.startswith(q) and s.endswith(q) and len(s) >= 2 * len(q):
+                s = s[len(q):-len(q)]
+                break
+        return textwrap.dedent(s).strip()
+
+    def _extract_return_type(self, fn_def_node) -> str:
+        ret = self._child_by_field(fn_def_node, "return_type")
+        if ret is None:
+            return ""
+        return self._text(ret).strip()
+
+    def _extract_params_json(self, fn_def_node) -> str:
+        params_node = self._child_by_field(fn_def_node, "parameters")
+        if params_node is None:
+            return "[]"
+        out: list[dict] = []
+        for c in params_node.named_children:
+            entry = self._param_to_dict(c)
+            if entry is not None:
+                out.append(entry)
+        return json.dumps(out, separators=(",", ":"))
+
+    def _param_to_dict(self, node) -> Optional[dict]:
+        t = node.type
+        if t == "identifier":
+            return {"name": self._text(node), "kind": "positional"}
+        if t == "list_splat_pattern":
+            return {"name": self._text(node), "kind": "var_positional"}
+        if t == "dictionary_splat_pattern":
+            return {"name": self._text(node), "kind": "var_keyword"}
+        if t in ("typed_parameter", "typed_default_parameter", "default_parameter"):
+            entry: dict[str, Any] = {"kind": "positional"}
+            name_field = self._child_by_field(node, "name")
+            type_field = self._child_by_field(node, "type")
+            value_field = self._child_by_field(node, "value")
+            if name_field is not None:
+                entry["name"] = self._text(name_field)
+            else:
+                # typed_parameter's name isn't a named field — scan children.
+                for c in node.children:
+                    if c.type == "identifier":
+                        entry["name"] = self._text(c)
+                        break
+                    if c.type == "list_splat_pattern":
+                        entry["name"] = self._text(c)
+                        entry["kind"] = "var_positional"
+                        break
+                    if c.type == "dictionary_splat_pattern":
+                        entry["name"] = self._text(c)
+                        entry["kind"] = "var_keyword"
+                        break
+            if type_field is not None:
+                entry["type"] = self._text(type_field).strip()
+            if value_field is not None:
+                entry["default"] = self._text(value_field).strip()
+            if "name" not in entry:
+                return None
+            return entry
+        return None
 
     # ── decorator naming ──────────────────────────────────────────────
 

--- a/codegraph/codegraph/py_parser.py
+++ b/codegraph/codegraph/py_parser.py
@@ -61,6 +61,19 @@ from .schema import (
 )
 
 
+def _descend(root):
+    """Iterative depth-first descent over a tree-sitter subtree.
+
+    Yields every descendant (including ``root``). Uses an explicit stack to
+    avoid Python recursion limits on deep method bodies.
+    """
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        yield node
+        stack.extend(node.children)
+
+
 class PyParserUnavailable(RuntimeError):
     """Raised when ``tree-sitter-python`` is not installed.
 
@@ -389,6 +402,96 @@ class _PyWalker:
                     src_id=method.id,
                     dst_id=f"dec:{dname}",
                 ))
+
+        # Method call graph (Phase 4 input — consumed by resolver)
+        body = self._child_by_field(node, "body")
+        if body is not None:
+            self._scan_body_for_calls(body, method)
+
+    # ── call classification ──────────────────────────────────────────
+
+    def _scan_body_for_calls(self, body, method: MethodNode) -> None:
+        """Walk every ``call`` node under a method body and emit call-graph refs.
+
+        Populates ``result.method_calls`` — the resolver then wires typed +
+        name-based :data:`~.schema.CALLS` edges across files in Phase 4.
+        Descendant walk catches calls nested in ``if`` / ``for`` / lambdas /
+        comprehensions.
+        """
+        for node in _descend(body):
+            if node.type != "call":
+                continue
+            fn = node.child_by_field_name("function")
+            if fn is None:
+                continue
+            recv_kind, recv_name, target = self._classify_py_call(fn)
+            if target:
+                self.result.method_calls.append(
+                    (method.id, recv_kind, recv_name or "", target)
+                )
+
+    def _classify_py_call(self, fn) -> tuple[str, Optional[str], Optional[str]]:
+        """Classify a ``call``'s function subexpression.
+
+        Returns ``(receiver_kind, receiver_name, target_method)`` using the TS
+        vocabulary so :mod:`~.resolver` Phase 4 logic slots in unchanged:
+
+        - ``"this"`` — resolver treats as ``confidence="typed"``. Used for
+          ``self.foo()`` and ``cls.foo()`` (classmethod invokes MRO like self).
+        - ``"this.field"`` — also typed; ``self.svc.run()``.
+        - ``"super"`` — new; resolver resolves via the enclosing class's first
+          ``class_extends`` parent (see :func:`.resolver.link_cross_file`).
+        - ``"name"`` — name-based resolution, ``confidence="name"``.
+
+        Falls back to ``("", None, None)`` when we can't identify a target.
+        """
+        if fn.type == "identifier":
+            # Bare call: foo()
+            return "name", None, self._text(fn)
+
+        if fn.type == "attribute":
+            obj = fn.child_by_field_name("object")
+            attr = fn.child_by_field_name("attribute")
+            if obj is None or attr is None:
+                return "", None, None
+            attr_name = self._text(attr)
+
+            # super().foo() — function-valued receiver, special-case super first.
+            if obj.type == "call":
+                obj_fn = obj.child_by_field_name("function")
+                if (obj_fn is not None
+                        and obj_fn.type == "identifier"
+                        and self._text(obj_fn) == "super"):
+                    return "super", None, attr_name
+                # get_obj().foo() — keep target, drop receiver name.
+                return "name", None, attr_name
+
+            # self.foo() / cls.foo() / obj.foo()
+            if obj.type == "identifier":
+                obj_name = self._text(obj)
+                if obj_name in ("self", "cls"):
+                    return "this", None, attr_name
+                return "name", obj_name, attr_name
+
+            # self.field.foo() or a.b.c.foo()
+            if obj.type == "attribute":
+                inner_obj = obj.child_by_field_name("object")
+                inner_attr = obj.child_by_field_name("attribute")
+                if inner_obj is None or inner_attr is None:
+                    return "", None, None
+                if (inner_obj.type == "identifier"
+                        and self._text(inner_obj) in ("self", "cls")):
+                    return "this.field", self._text(inner_attr), attr_name
+                # Deeper chain (a.b.c.m()) — use the immediately-preceding
+                # attribute as the receiver name; best-effort name resolution.
+                return "name", self._text(inner_attr), attr_name
+
+            # Subscripts (a[0].m()), parenthesized wrappers — keep target only.
+            return "name", None, attr_name
+
+        # Parenthesized / walrus / anything else — skip (descendant walk
+        # still finds inner calls via separate visits).
+        return "", None, None
 
     # ── functions (module level) ──────────────────────────────────────
 

--- a/codegraph/codegraph/py_parser.py
+++ b/codegraph/codegraph/py_parser.py
@@ -1,0 +1,465 @@
+"""Python frontend for codegraph (Stage 1 — minimum viable).
+
+Walks a Python source file with ``tree-sitter-python`` and emits the same
+:class:`ParseResult` dataclass that :class:`~.parser.TsParser` produces. The
+downstream resolver / loader pipeline is language-agnostic and consumes both.
+
+Scope (Stage 1):
+
+- Module files (``.py``) → :class:`~.schema.FileNode` with ``language="py"``
+- Top-level classes → :class:`~.schema.ClassNode`
+- Top-level functions → :class:`~.schema.FunctionNode`
+- Methods inside classes → :class:`~.schema.MethodNode`
+- Imports (``import x``, ``from x import y``, relative ``from .x import y``)
+  → :class:`~.schema.ImportSpec`
+- Class inheritance → ``class_extends`` name-ref pairs (resolver wires edges)
+- Decorators on classes and functions → ``DECORATED_BY`` edges with a
+  canonical stringified decorator name (``dataclass``, ``property``,
+  ``app.command()``, ``mcp.tool()``, etc.)
+
+Out of scope (Stage 2+):
+- Framework detection (Typer / pytest / FastAPI / Flask / Django)
+- Route endpoint extraction
+- Method call graph
+- ORM column detection
+- Type annotation extraction
+- Python ``Protocol`` / ``ABC`` → :class:`~.schema.InterfaceNode` mapping
+
+Ported to mirror ``TsParser``'s public interface so ``cli._run_index`` can
+dispatch by file extension without special-casing downstream code.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+try:
+    from tree_sitter import Language, Parser
+    import tree_sitter_python as tsp
+    _LANG_PY: Optional["Language"] = Language(tsp.language())
+except ImportError:  # pragma: no cover
+    # tree-sitter-python is an optional dep under the `[python]` extra.
+    # Importing codegraph.py_parser without it should NOT crash the whole
+    # package — we raise a clear error at first use instead.
+    _LANG_PY = None
+
+
+from .schema import (
+    ClassNode,
+    DECORATED_BY,
+    DEFINES_CLASS,
+    DEFINES_FUNC,
+    Edge,
+    FileNode,
+    FunctionNode,
+    HAS_METHOD,
+    ImportSpec,
+    MethodNode,
+    ParseResult,
+)
+
+
+class PyParserUnavailable(RuntimeError):
+    """Raised when ``tree-sitter-python`` is not installed.
+
+    The ``[python]`` extra provides it:
+
+        pip install "codegraph[python]"
+    """
+
+
+class PyParser:
+    """Stateless Python source parser. One instance per indexing run."""
+
+    def __init__(self) -> None:
+        if _LANG_PY is None:
+            raise PyParserUnavailable(
+                "tree-sitter-python is not installed. Install the [python] extra:\n"
+                '    pip install "codegraph[python]"'
+            )
+        self._parser = Parser(_LANG_PY)
+
+    def parse_file(
+        self,
+        path: Path,
+        rel_path: str,
+        package: str,
+        is_test: bool = False,
+    ) -> Optional[ParseResult]:
+        """Parse a single ``.py`` file into a :class:`ParseResult`.
+
+        Returns ``None`` if the file can't be read (matching ``TsParser``'s
+        behaviour). tree-sitter-python never raises on a parse — it emits
+        ``error`` nodes for malformed regions, which we simply skip.
+        """
+        try:
+            src = path.read_bytes()
+        except OSError:
+            return None
+
+        tree = self._parser.parse(src)
+        loc = src.count(b"\n") + 1
+
+        file_node = FileNode(
+            path=rel_path,
+            package=package,
+            language="py",
+            loc=loc,
+            is_test=is_test,
+        )
+        result = ParseResult(file=file_node)
+        walker = _PyWalker(src, result)
+        walker.walk_module(tree.root_node)
+        return result
+
+
+# ── Walker internals ─────────────────────────────────────────────────
+
+
+class _PyWalker:
+    """Walks a ``module`` root and populates a :class:`ParseResult`.
+
+    Node types used (all from ``tree-sitter-python`` 0.23):
+    - ``module``
+    - ``class_definition``
+    - ``function_definition``
+    - ``decorated_definition`` (wraps a class/function with its decorators)
+    - ``decorator`` (the ``@expr`` line itself)
+    - ``import_statement`` (``import x``, ``import x as y``)
+    - ``import_from_statement`` (``from x import y``)
+    - ``future_import_statement`` (``from __future__ import ...``)
+    - ``try_statement`` (for try/except imports — walked into normally)
+    - ``identifier``, ``dotted_name``, ``aliased_import``
+    """
+
+    def __init__(self, src: bytes, result: ParseResult) -> None:
+        self.src = src
+        self.result = result
+
+    # ── text helpers ──────────────────────────────────────────────────
+
+    def _text(self, node) -> str:
+        return self.src[node.start_byte:node.end_byte].decode("utf-8", "replace")
+
+    def _child_by_field(self, node, field_name: str):
+        return node.child_by_field_name(field_name)
+
+    # ── entry point ───────────────────────────────────────────────────
+
+    def walk_module(self, root) -> None:
+        """Walk the top-level statements of a module.
+
+        Iterates children of the ``module`` root and recurses into
+        ``try_statement`` / ``if_statement`` bodies so try/except imports
+        and conditional imports are captured. Class / function bodies are
+        handled by dedicated helpers.
+        """
+        for child in root.children:
+            self._walk_top_stmt(child)
+
+    def _walk_top_stmt(self, node) -> None:
+        t = node.type
+
+        if t == "class_definition":
+            self._handle_class(node, decorators=[])
+        elif t == "function_definition":
+            self._handle_function(node, decorators=[])
+        elif t == "decorated_definition":
+            decorators = [c for c in node.children if c.type == "decorator"]
+            target = self._child_by_field(node, "definition")
+            if target is None:
+                # Fall back: look for the first class_definition / function_definition child.
+                for c in node.children:
+                    if c.type in ("class_definition", "function_definition"):
+                        target = c
+                        break
+            if target is None:
+                return
+            if target.type == "class_definition":
+                self._handle_class(target, decorators=decorators)
+            elif target.type == "function_definition":
+                self._handle_function(target, decorators=decorators)
+        elif t == "import_statement":
+            self._handle_import(node)
+        elif t == "import_from_statement":
+            self._handle_from_import(node)
+        elif t == "future_import_statement":
+            # `from __future__ import annotations` and friends — emit as an
+            # import for graph completeness but it'll always resolve to
+            # `:External {specifier:"__future__"}`.
+            spec = ImportSpec(specifier="__future__", symbols=self._from_import_symbols(node))
+            self.result.imports.append(spec)
+        elif t in ("try_statement", "if_statement", "with_statement"):
+            # Walk into the body — catches try/except imports, conditional
+            # imports under `if sys.version_info >= (3, 11):`, etc.
+            for c in node.children:
+                self._walk_top_stmt(c)
+        elif t == "block":
+            for c in node.children:
+                self._walk_top_stmt(c)
+        elif t == "except_clause":
+            for c in node.children:
+                self._walk_top_stmt(c)
+        elif t == "else_clause":
+            for c in node.children:
+                self._walk_top_stmt(c)
+
+    # ── imports ───────────────────────────────────────────────────────
+
+    def _handle_import(self, node) -> None:
+        """``import x`` or ``import x as y`` (possibly multiple, comma-sep)."""
+        for child in node.children:
+            if child.type == "dotted_name":
+                self.result.imports.append(ImportSpec(
+                    specifier=self._text(child),
+                    symbols=[],
+                ))
+            elif child.type == "aliased_import":
+                # ``import x as y``
+                name = self._child_by_field(child, "name")
+                alias = self._child_by_field(child, "alias")
+                if name is not None:
+                    self.result.imports.append(ImportSpec(
+                        specifier=self._text(name),
+                        namespace=self._text(alias) if alias else None,
+                        symbols=[],
+                    ))
+
+    def _handle_from_import(self, node) -> None:
+        """``from x import y`` / ``from .x import y`` / ``from ..x import y``.
+
+        tree-sitter-python's ``module_name`` field points at the entire
+        module expression — for relative imports that's a ``relative_import``
+        wrapper containing the ``import_prefix`` (dots) and an optional
+        ``dotted_name``. Unwrap that here.
+        """
+        module_node = self._child_by_field(node, "module_name")
+        dots = 0
+
+        if module_node is not None and module_node.type == "relative_import":
+            inner_module = None
+            for rc in module_node.children:
+                if rc.type == "import_prefix":
+                    dots = len(self._text(rc))
+                elif rc.type == "dotted_name":
+                    inner_module = rc
+            module_node = inner_module  # may be None for bare `from . import X`
+
+        if module_node is None and dots == 0:
+            return  # malformed
+
+        specifier = ("." * dots) + (self._text(module_node) if module_node else "")
+        symbols = self._from_import_symbols(node)
+        self.result.imports.append(ImportSpec(
+            specifier=specifier,
+            symbols=symbols,
+        ))
+
+    def _from_import_symbols(self, node) -> list[str]:
+        """Extract the imported names from a ``from ... import ...`` node."""
+        symbols: list[str] = []
+        saw_import = False
+        for c in node.children:
+            if c.type == "import":
+                saw_import = True
+                continue
+            if not saw_import:
+                continue
+            if c.type == "dotted_name":
+                symbols.append(self._text(c))
+            elif c.type == "aliased_import":
+                name = self._child_by_field(c, "name")
+                if name is not None:
+                    symbols.append(self._text(name))
+            elif c.type == "wildcard_import":
+                symbols.append("*")
+        return symbols
+
+    # ── classes ───────────────────────────────────────────────────────
+
+    def _handle_class(self, node, decorators) -> None:
+        name_node = self._child_by_field(node, "name")
+        if name_node is None:
+            return
+        name = self._text(name_node)
+        rel = self.result.file.path
+        cls = ClassNode(name=name, file=rel, is_abstract=False)
+        self.result.classes.append(cls)
+
+        # DEFINES_CLASS edge
+        self.result.edges.append(Edge(
+            kind=DEFINES_CLASS,
+            src_id=self.result.file.id,
+            dst_id=cls.id,
+        ))
+
+        # Base classes → class_extends name-refs + is_abstract detection
+        superclasses = self._child_by_field(node, "superclasses")
+        if superclasses is not None:
+            for c in superclasses.children:
+                if c.type in ("identifier", "attribute", "dotted_name"):
+                    base_name = self._text(c).split(".")[-1]
+                    if base_name in ("ABC", "ABCMeta"):
+                        cls.is_abstract = True
+                    self.result.class_extends.append((name, base_name))
+
+        # Class-level decorators
+        for dec in decorators:
+            dname = self._decorator_name(dec)
+            if dname:
+                self.result.edges.append(Edge(
+                    kind=DECORATED_BY,
+                    src_id=cls.id,
+                    dst_id=f"dec:{dname}",
+                ))
+
+        # Walk body for methods
+        body = self._child_by_field(node, "body")
+        if body is not None:
+            self._walk_class_body(body, cls)
+
+    def _walk_class_body(self, body, cls: ClassNode) -> None:
+        for child in body.children:
+            if child.type == "function_definition":
+                self._handle_method(child, cls, decorators=[])
+            elif child.type == "decorated_definition":
+                decorators = [c for c in child.children if c.type == "decorator"]
+                target = self._child_by_field(child, "definition")
+                if target is None:
+                    for c in child.children:
+                        if c.type in ("class_definition", "function_definition"):
+                            target = c
+                            break
+                if target is None:
+                    continue
+                if target.type == "function_definition":
+                    self._handle_method(target, cls, decorators=decorators)
+                elif target.type == "class_definition":
+                    # Nested class — treat as a top-level class for simplicity.
+                    self._handle_class(target, decorators=decorators)
+
+    # ── methods ───────────────────────────────────────────────────────
+
+    def _handle_method(self, node, cls: ClassNode, decorators) -> None:
+        name_node = self._child_by_field(node, "name")
+        if name_node is None:
+            return
+        name = self._text(name_node)
+
+        is_static = False
+        is_constructor = (name == "__init__")
+        for dec in decorators:
+            dname = self._decorator_name(dec)
+            if dname == "staticmethod":
+                is_static = True
+
+        visibility = "private" if name.startswith("_") and not name.startswith("__") else "public"
+        if name.startswith("__") and name.endswith("__"):
+            visibility = "public"  # dunder methods are public API
+
+        method = MethodNode(
+            name=name,
+            class_id=cls.id,
+            file=self.result.file.path,
+            is_static=is_static,
+            is_async=False,
+            is_constructor=is_constructor,
+            visibility=visibility,
+            return_type="",
+            params_json="[]",
+        )
+        self.result.methods.append(method)
+
+        # HAS_METHOD edge
+        self.result.edges.append(Edge(
+            kind=HAS_METHOD,
+            src_id=cls.id,
+            dst_id=method.id,
+        ))
+
+        # Method decorators
+        for dec in decorators:
+            dname = self._decorator_name(dec)
+            if dname:
+                self.result.edges.append(Edge(
+                    kind=DECORATED_BY,
+                    src_id=method.id,
+                    dst_id=f"dec:{dname}",
+                ))
+
+    # ── functions (module level) ──────────────────────────────────────
+
+    def _handle_function(self, node, decorators) -> None:
+        name_node = self._child_by_field(node, "name")
+        if name_node is None:
+            return
+        name = self._text(name_node)
+        rel = self.result.file.path
+        fn = FunctionNode(
+            name=name,
+            file=rel,
+            is_component=False,  # never — that flag is TS/React-specific
+            exported=True,       # Python has no `export`; module-level = importable
+        )
+        self.result.functions.append(fn)
+
+        # DEFINES_FUNC edge
+        self.result.edges.append(Edge(
+            kind=DEFINES_FUNC,
+            src_id=self.result.file.id,
+            dst_id=fn.id,
+        ))
+
+        # Function decorators
+        for dec in decorators:
+            dname = self._decorator_name(dec)
+            if dname:
+                self.result.edges.append(Edge(
+                    kind=DECORATED_BY,
+                    src_id=fn.id,
+                    dst_id=f"dec:{dname}",
+                ))
+
+    # ── decorator naming ──────────────────────────────────────────────
+
+    def _decorator_name(self, dec) -> Optional[str]:
+        """Stringify a decorator into a canonical name.
+
+        Examples:
+        - ``@dataclass`` → ``"dataclass"``
+        - ``@property`` → ``"property"``
+        - ``@app.command()`` → ``"app.command()"``
+        - ``@mcp.tool()`` → ``"mcp.tool()"``
+        - ``@pytest.mark.parametrize("x", [...])`` → ``"pytest.mark.parametrize()"``
+
+        Arguments inside ``()`` are dropped. The name is the callable
+        expression, optionally followed by ``()`` to distinguish a bare
+        decorator (``@dataclass``) from a parameterised one
+        (``@dataclass()``). This matches the pattern a user would write
+        in a Cypher query: ``MATCH (:Decorator {name:'dataclass'})``.
+        """
+        # A decorator node has the shape `@ <expression> [newline]`.
+        # Pull the expression — it's the first non-`@` / non-newline child.
+        expr = None
+        for c in dec.children:
+            if c.type in ("@", "comment"):
+                continue
+            if c.type == "\n" or c.type == "newline":
+                continue
+            expr = c
+            break
+        if expr is None:
+            return None
+
+        if expr.type == "identifier":
+            return self._text(expr)
+        if expr.type in ("attribute", "dotted_name"):
+            return self._text(expr)
+        if expr.type == "call":
+            fn = self._child_by_field(expr, "function")
+            if fn is None:
+                return None
+            base = self._text(fn)
+            return f"{base}()"
+        # Fallback: take the full source slice and hope it's short.
+        return self._text(expr).split("(")[0]

--- a/codegraph/codegraph/repl.py
+++ b/codegraph/codegraph/repl.py
@@ -1,0 +1,319 @@
+"""Interactive REPL for codegraph.
+
+Entered when ``codegraph`` is invoked without a subcommand, or via
+``codegraph repl``. Built on top of the ``ReplSkin`` vendored from
+cli-anything. Stateful: remembers the current repo and Neo4j connection
+across invocations via :class:`codegraph.session.Session`.
+
+Commands (type ``help`` in the REPL to see this list at runtime):
+
+    help                     Show this command list
+    status                   Print current repo + connection
+    repo <path>              Set the current repo (for validate/index)
+    connect [uri] [user]     Connect to Neo4j; prompts for password
+    index [--no-wipe]        Index the current repo
+    validate                 Run the validation suite
+    query <cypher...>        Run a Cypher query
+    schema                   Print the graph schema (node labels + edge types)
+    last                     Show the last query and its row count
+    clear                    Clear the screen
+    save                     Persist session state to disk now
+    quit / exit              Leave the REPL
+"""
+from __future__ import annotations
+
+import shlex
+import sys
+from getpass import getpass
+from pathlib import Path
+from typing import Optional
+
+from neo4j import GraphDatabase
+
+from .session import Session
+from .utils.repl_skin import ReplSkin
+
+
+# ── Command registry for help / dispatch ─────────────────────────────
+
+_COMMANDS: dict[str, str] = {
+    "help":                  "Show this command list",
+    "status":                "Print current repo + connection",
+    "repo <path>":           "Set the current repo (for validate/index)",
+    "connect [uri] [user]":  "Connect to Neo4j; prompts for password",
+    "index":                 "Index the current repo (use --no-wipe to keep existing data)",
+    "validate":              "Run the validation suite on the current repo",
+    "query <cypher>":        "Run a Cypher query (wrap multi-word args in quotes)",
+    "schema":                "Print the graph schema (node labels + edge types)",
+    "last":                  "Show the last query run this session",
+    "clear":                 "Clear the screen",
+    "save":                  "Persist session state to disk now",
+    "quit / exit":           "Leave the REPL",
+}
+
+_VERSION = "0.1.0"
+
+
+# ── Entry point ──────────────────────────────────────────────────────
+
+def run_repl(
+    *,
+    repo: Optional[Path] = None,
+    uri: Optional[str] = None,
+    user: Optional[str] = None,
+    password: Optional[str] = None,
+) -> int:
+    """Run the interactive REPL until the user quits.
+
+    Any arguments override values loaded from the persisted session. Returns
+    a shell exit code (0 on clean exit, non-zero only if startup fails).
+    """
+    skin = ReplSkin("codegraph", version=_VERSION)
+    session = Session.load()
+
+    # Apply overrides from the CLI layer
+    if repo is not None:
+        session.set_repo(str(repo))
+    if uri is not None:
+        session.uri = uri
+    if user is not None:
+        session.user = user
+    if password is not None:
+        session.password = password
+
+    skin.print_banner()
+    skin.status_block(session.summary(), title="Session")
+    print()
+
+    pt_session = skin.create_prompt_session()  # None if prompt_toolkit missing
+
+    while True:
+        try:
+            repo_label = Path(session.repo).name if session.repo else ""
+            line = skin.get_input(
+                pt_session,
+                project_name=repo_label,
+                modified=False,
+            )
+        except (EOFError, KeyboardInterrupt):
+            print()
+            skin.print_goodbye()
+            session.save()
+            return 0
+
+        if not line:
+            continue
+
+        try:
+            cmd, *args = shlex.split(line)
+        except ValueError as e:
+            skin.error(f"Parse error: {e}")
+            continue
+
+        cmd = cmd.lower()
+        try:
+            if cmd in ("quit", "exit", "q"):
+                session.save()
+                skin.print_goodbye()
+                return 0
+            elif cmd == "help":
+                skin.help(_COMMANDS)
+            elif cmd == "status":
+                skin.status_block(session.summary(), title="Session")
+                if session.last_index_stats:
+                    skin.section("Last index stats")
+                    skin.status_block(
+                        {k: str(v) for k, v in session.last_index_stats.items()},
+                    )
+                print()
+            elif cmd == "repo":
+                _cmd_repo(skin, session, args)
+            elif cmd == "connect":
+                _cmd_connect(skin, session, args)
+            elif cmd == "index":
+                _cmd_index(skin, session, args)
+            elif cmd == "validate":
+                _cmd_validate(skin, session)
+            elif cmd == "query":
+                _cmd_query(skin, session, args, raw_line=line)
+            elif cmd == "schema":
+                _cmd_schema(skin, session)
+            elif cmd == "last":
+                _cmd_last(skin, session)
+            elif cmd == "clear":
+                # ANSI clear-and-home; no shell invocation.
+                sys.stdout.write("\033[2J\033[H")
+                sys.stdout.flush()
+            elif cmd == "save":
+                session.save()
+                skin.success("Session saved")
+            else:
+                skin.error(f"Unknown command: {cmd!r}. Type `help` for the list.")
+        except Exception as e:  # noqa: BLE001
+            # REPL should survive any single-command failure.
+            skin.error(f"{type(e).__name__}: {e}")
+
+
+# ── Individual command handlers ──────────────────────────────────────
+
+def _cmd_repo(skin: ReplSkin, session: Session, args: list[str]) -> None:
+    if not args:
+        skin.hint(f"Usage: repo <path>    (current: {session.repo or '(none)'})")
+        return
+    path = Path(args[0]).expanduser().resolve()
+    if not path.exists() or not path.is_dir():
+        skin.error(f"Not a directory: {path}")
+        return
+    session.set_repo(str(path))
+    skin.success(f"Repo set to {path}")
+
+
+def _cmd_connect(skin: ReplSkin, session: Session, args: list[str]) -> None:
+    uri = args[0] if len(args) > 0 else session.uri or "bolt://localhost:7688"
+    user = args[1] if len(args) > 1 else session.user or "neo4j"
+    password = session.password or getpass(f"Password for {user}@{uri}: ")
+
+    skin.info(f"Connecting to {uri} as {user}...")
+    try:
+        driver = GraphDatabase.driver(uri, auth=(user, password))
+        driver.verify_connectivity()
+        driver.close()
+    except Exception as e:  # noqa: BLE001
+        skin.error(f"Connection failed: {e}")
+        return
+
+    session.set_connection(uri, user, password)
+    skin.success(f"Connected to {uri}")
+
+
+def _cmd_index(skin: ReplSkin, session: Session, args: list[str]) -> None:
+    if not session.repo:
+        skin.error("No repo set. Run `repo <path>` first.")
+        return
+    if not session.uri:
+        skin.error("Not connected to Neo4j. Run `connect` first.")
+        return
+
+    wipe = "--no-wipe" not in args
+
+    # Dynamically import to keep REPL startup fast
+    from .cli import _run_index  # type: ignore[attr-defined]
+
+    skin.info(f"Indexing {session.repo}" + (" (wiping first)" if wipe else ""))
+    try:
+        stats = _run_index(
+            repo=Path(session.repo),
+            packages=None,
+            wipe=wipe,
+            uri=session.uri,
+            user=session.user or "neo4j",
+            password=session.password or "",
+            skip_ownership=False,
+        )
+        session.last_index_stats = stats
+        skin.success("Index complete.")
+        skin.status_block({k: str(v) for k, v in stats.items()})
+    except Exception as e:  # noqa: BLE001
+        skin.error(f"Index failed: {e}")
+
+
+def _cmd_validate(skin: ReplSkin, session: Session) -> None:
+    if not session.repo:
+        skin.error("No repo set. Run `repo <path>` first.")
+        return
+    if not session.uri:
+        skin.error("Not connected to Neo4j. Run `connect` first.")
+        return
+
+    from .validate import run_validation
+
+    report = run_validation(
+        session.uri,
+        session.user or "neo4j",
+        session.password or "",
+        Path(session.repo),
+        console=None,  # run_validation tolerates None
+    )
+    if report.ok:
+        skin.success("Validation passed")
+    else:
+        skin.error("Validation failed — see report above")
+
+
+def _cmd_query(skin: ReplSkin, session: Session, args: list[str], raw_line: str) -> None:
+    if not session.uri:
+        skin.error("Not connected to Neo4j. Run `connect` first.")
+        return
+    # Accept both `query "MATCH ..."` and `query MATCH ...` (rest of line)
+    cypher = " ".join(args) if len(args) > 1 else (args[0] if args else "")
+    if not cypher:
+        cypher = raw_line.split(" ", 1)[1] if " " in raw_line else ""
+    if not cypher:
+        skin.hint("Usage: query <cypher>")
+        return
+
+    session.last_query = cypher
+    try:
+        driver = GraphDatabase.driver(
+            session.uri,
+            auth=(session.user or "neo4j", session.password or ""),
+        )
+        with driver.session() as s:
+            rows = list(s.run(cypher))
+        driver.close()
+    except Exception as e:  # noqa: BLE001
+        skin.error(f"Query failed: {e}")
+        return
+
+    if not rows:
+        skin.hint("(no rows)")
+        return
+
+    headers = list(rows[0].keys())
+    body = [[str(r.get(h, "")) for h in headers] for r in rows[:50]]
+    skin.table(headers, body)
+    skin.hint(f"{len(rows)} row(s)" + (" — showing first 50" if len(rows) > 50 else ""))
+
+
+def _cmd_schema(skin: ReplSkin, session: Session) -> None:
+    if not session.uri:
+        skin.error("Not connected to Neo4j. Run `connect` first.")
+        return
+    try:
+        driver = GraphDatabase.driver(
+            session.uri,
+            auth=(session.user or "neo4j", session.password or ""),
+        )
+        with driver.session() as s:
+            labels = [
+                r["label"]
+                for r in s.run("CALL db.labels() YIELD label RETURN label ORDER BY label")
+            ]
+            types = [
+                r["relationshipType"]
+                for r in s.run(
+                    "CALL db.relationshipTypes() YIELD relationshipType "
+                    "RETURN relationshipType ORDER BY relationshipType"
+                )
+            ]
+        driver.close()
+    except Exception as e:  # noqa: BLE001
+        skin.error(f"Schema fetch failed: {e}")
+        return
+
+    skin.section("Node labels")
+    for label in labels:
+        print(f"    {label}")
+    skin.section("Edge types")
+    for t in types:
+        print(f"    {t}")
+    print()
+
+
+def _cmd_last(skin: ReplSkin, session: Session) -> None:
+    if not session.last_query:
+        skin.hint("No query yet this session.")
+        return
+    skin.section("Last query")
+    print(f"    {session.last_query}")
+    print()

--- a/codegraph/codegraph/resolver.py
+++ b/codegraph/codegraph/resolver.py
@@ -22,6 +22,7 @@ from .schema import (
     IMPORTS_SYMBOL,
     INJECTS,
     MethodNode,
+    PackageNode,
     ParseResult,
     PROVIDES,
     RELATES_TO,
@@ -122,6 +123,8 @@ class Index:
     # Phase 3: endpoint lookup structures
     endpoint_nodes: list = field(default_factory=list)  # list of (EndpointNode, file_id)
     gql_operations: dict[tuple[str, str], list] = field(default_factory=dict)  # (op_type, name) -> list of (op, file)
+    # Phase 9: per-package framework detection
+    packages: list[PackageNode] = field(default_factory=list)
 
     def add(self, result: ParseResult) -> None:
         path = result.file.path

--- a/codegraph/codegraph/resolver.py
+++ b/codegraph/codegraph/resolver.py
@@ -490,17 +490,22 @@ def link_cross_file(index: Index, resolver: Resolver) -> list[Edge]:
 
         # -- Phase 4: method CALLS --
         for caller_mid, recv_kind, recv_name, target_method in result.method_calls:
-            # Figure out target class
-            target_class_id = _resolve_call_target_class(
-                rel, caller_mid, recv_kind, recv_name, index
-            )
+            # Figure out target class (super() takes a special path).
+            if recv_kind == "super":
+                target_class_id = _resolve_super_target_class(
+                    rel, caller_mid, result, index, resolver
+                )
+            else:
+                target_class_id = _resolve_call_target_class(
+                    rel, caller_mid, recv_kind, recv_name, index
+                )
             if target_class_id is None:
                 continue
             # Does target class have target_method?
             key = (target_class_id, target_method)
             if key in index.method_by_class_and_name:
                 m = index.method_by_class_and_name[key]
-                confidence = "typed" if recv_kind in ("this", "this.field") else "name"
+                confidence = "typed" if recv_kind in ("this", "this.field", "super") else "name"
                 edges.append(Edge(
                     kind=CALLS,
                     src_id=caller_mid,
@@ -620,6 +625,35 @@ def _resolve_call_target_class(
         if len(hits) == 1:
             return f"class:{hits[0]}#{recv_name}"
     return None
+
+
+def _resolve_super_target_class(
+    importer: str,
+    caller_mid: str,
+    result: ParseResult,
+    index: Index,
+    resolver: Resolver,
+) -> Optional[str]:
+    """Resolve the target class for a ``super().foo()`` call.
+
+    Walks the enclosing class's first parent in :attr:`ParseResult.class_extends`
+    and returns the parent's ``class:{file}#{name}`` id, or ``None`` if the
+    parent isn't in the indexed graph (external bases like ``Exception`` /
+    ``Enum`` / ``ABC`` fall through).
+    """
+    if not caller_mid.startswith("method:class:"):
+        return None
+    class_id = caller_mid[len("method:"):].rsplit("#", 1)[0]
+    cls_name = class_id.split("#", 1)[1] if "#" in class_id else ""
+    if not cls_name:
+        return None
+    parents = [p for (c, p) in result.class_extends if c == cls_name]
+    if not parents:
+        return None
+    target_file = _find_class(importer, parents[0], index, resolver)
+    if target_file is None:
+        return None
+    return f"class:{target_file}#{parents[0]}"
 
 
 def _capitalize_guess(name: str) -> str:

--- a/codegraph/codegraph/resolver.py
+++ b/codegraph/codegraph/resolver.py
@@ -454,15 +454,16 @@ def link_cross_file(index: Index, resolver: Resolver) -> list[Edge]:
 
 
 def _caller_id_for_fn(rel: str, caller_name: str, index: Index) -> str:
-    """Figure out whether caller_name is a :Function or :Method."""
-    # Prefer function (components) first
-    if (rel, caller_name) in index.func_by_name_in_file:
+    """Figure out whether caller_name is a :Function, :Method, or fall back to :File."""
+    if caller_name and (rel, caller_name) in index.func_by_name_in_file:
         return f"func:{rel}#{caller_name}"
-    # Scan methods in this file for matching name (prefer first hit)
-    for (class_id, mname), _m in index.method_by_class_and_name.items():
-        if mname == caller_name and class_id.startswith(f"class:{rel}#"):
-            return f"method:{class_id}#{mname}"
-    return f"func:{rel}#{caller_name}"
+    # Scan methods in this file for matching name
+    if caller_name:
+        for (class_id, mname), _m in index.method_by_class_and_name.items():
+            if mname == caller_name and class_id.startswith(f"class:{rel}#"):
+                return f"method:{class_id}#{mname}"
+    # Fallback: attribute to file
+    return f"file:{rel}"
 
 
 def _resolve_call_target_class(

--- a/codegraph/codegraph/resolver.py
+++ b/codegraph/codegraph/resolver.py
@@ -97,6 +97,7 @@ class PackageConfig:
     root: Path
     repo_root: Path
     aliases: dict[str, list[Path]] = field(default_factory=dict)
+    language: str = "ts"  # "ts" (TypeScript/TSX) or "py" (Python)
 
 
 def load_package_config(repo_root: Path, package_dir: Path) -> PackageConfig:
@@ -108,6 +109,25 @@ def load_package_config(repo_root: Path, package_dir: Path) -> PackageConfig:
             resolved.append((package_dir / t.rstrip("*")).resolve())
         cfg.aliases[alias_prefix] = resolved
     return cfg
+
+
+def load_python_package_config(repo_root: Path, package_dir: Path) -> PackageConfig:
+    """Build a :class:`PackageConfig` for a Python package directory.
+
+    Unlike TS, Python has no tsconfig equivalent — imports are resolved
+    purely by filesystem layout (relative imports walk up, absolute imports
+    match the top-level package name and resolve under the package root).
+    The returned config has ``language="py"`` and empty ``aliases``. The
+    ``name`` is the directory basename, which doubles as the Python
+    top-level package name (what ``from <name> import ...`` would use).
+    """
+    return PackageConfig(
+        name=package_dir.name,
+        root=package_dir.resolve(),
+        repo_root=repo_root.resolve(),
+        aliases={},
+        language="py",
+    )
 
 
 # ── Index ────────────────────────────────────────────────────
@@ -193,6 +213,11 @@ class Resolver:
         if not spec:
             return None
 
+        # Python files dispatch to their own resolver — TS logic (extension
+        # candidates, tsconfig aliases, .d.ts fallback) doesn't apply.
+        if self._is_python_file(importer_rel):
+            return self._resolve_python(importer_rel, spec)
+
         # Relative
         if spec.startswith("."):
             importer_abs = (self.repo_root / importer_rel).resolve()
@@ -221,6 +246,95 @@ class Resolver:
                     if hit:
                         return hit
         return None
+
+    # ── Python resolution ─────────────────────────────────────────────
+
+    def _is_python_file(self, rel: str) -> bool:
+        """Check if ``rel`` lives under a Python package (``language=="py"``)."""
+        abs_path = (self.repo_root / rel).resolve()
+        for pkg in self.packages:
+            if pkg.language != "py":
+                continue
+            try:
+                abs_path.relative_to(pkg.root)
+                return True
+            except ValueError:
+                continue
+        return False
+
+    def _resolve_python(self, importer_rel: str, spec: str) -> Optional[str]:
+        """Resolve a Python import specifier to a rel file path, or ``None``.
+
+        Three rules:
+
+        1. **Relative** (``.x`` / ``..x`` / ``.``): walk up ``dots - 1``
+           directories from the importer's parent, then resolve the
+           remainder as a module path.
+        2. **Absolute intra-package** (``codegraph.schema``): if the first
+           segment matches a Python package's ``name``, strip it and
+           resolve under the package root.
+        3. **External**: return ``None``; the caller emits an
+           ``IMPORTS_EXTERNAL`` edge.
+        """
+        # Count leading dots (relative import level).
+        leading_dots = 0
+        while leading_dots < len(spec) and spec[leading_dots] == ".":
+            leading_dots += 1
+
+        if leading_dots > 0:
+            remainder = spec[leading_dots:]
+            importer_abs = (self.repo_root / importer_rel).resolve()
+            base = importer_abs.parent
+            for _ in range(leading_dots - 1):
+                base = base.parent
+            return self._resolve_python_module(base, remainder)
+
+        # Absolute intra-package import: strip the top-level name.
+        first = spec.split(".")[0]
+        for pkg in self.packages:
+            if pkg.language != "py":
+                continue
+            if pkg.name == first:
+                remainder = ".".join(spec.split(".")[1:])
+                return self._resolve_python_module(pkg.root, remainder)
+
+        # External — the caller emits IMPORTS_EXTERNAL.
+        return None
+
+    def _resolve_python_module(self, base: Path, module_path: str) -> Optional[str]:
+        """Given a filesystem base + a dotted module path, find a ``.py`` file.
+
+        Tries the module as a plain file (``base/foo/bar.py``) first, then as
+        a package (``base/foo/bar/__init__.py``). Returns the repo-relative
+        path if found in the path index, else ``None``.
+        """
+        if self._path_index is None:
+            return None
+
+        if not module_path:
+            # ``from . import X`` → base/__init__.py
+            candidate = base / "__init__.py"
+            return self._path_index_membership(candidate)
+
+        parts = module_path.split(".")
+        # Try as .py file.
+        file_candidate = base.joinpath(*parts).with_suffix(".py")
+        hit = self._path_index_membership(file_candidate)
+        if hit is not None:
+            return hit
+        # Try as package: <parts>/__init__.py
+        pkg_candidate = base.joinpath(*parts) / "__init__.py"
+        return self._path_index_membership(pkg_candidate)
+
+    def _path_index_membership(self, candidate: Path) -> Optional[str]:
+        """Return the rel path if ``candidate`` is in the path index, else None."""
+        if self._path_index is None:
+            return None
+        try:
+            rel = str(candidate.resolve().relative_to(self.repo_root)).replace("\\", "/")
+        except ValueError:
+            return None
+        return rel if rel in self._path_index.files else None
 
 
 # ── URL matching for Phase 3 ─────────────────────────────────

--- a/codegraph/codegraph/resolver.py
+++ b/codegraph/codegraph/resolver.py
@@ -223,10 +223,11 @@ class Resolver:
 # ── URL matching for Phase 3 ─────────────────────────────────
 
 def _url_pattern_to_regex(path_template: str) -> re.Pattern:
-    """Convert '/rest/users/:id' → '^/rest/users/[^/]+$'."""
+    """Convert '/rest/users/:id' → '^/rest/users/[^/]+$' (with prefix tolerance)."""
     escaped = re.escape(path_template)
-    escaped = re.sub(r"\\:[A-Za-z_]\w*", r"[^/]+", escaped)
-    return re.compile(f"^{escaped}$")
+    escaped = re.sub(r"\\:[A-Za-z_]\w*", r"[^/?#]+", escaped)
+    # Allow trailing slashes / query strings
+    return re.compile(f"^{escaped}/?(?:[?#].*)?$")
 
 
 # ── Cross-file linker ────────────────────────────────────────

--- a/codegraph/codegraph/schema.py
+++ b/codegraph/codegraph/schema.py
@@ -2,10 +2,56 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .framework import FrameworkInfo
 
 
 # ── Nodes ────────────────────────────────────────────────────
+
+@dataclass
+class PackageNode:
+    """A monorepo package with per-package framework detection.
+
+    Mirrors :class:`codegraph.framework.FrameworkInfo` as a flat set of
+    properties so every field is queryable directly in Cypher without a join.
+    The ``name`` matches the ``package`` string already stored on
+    :class:`FileNode`, and :class:`FileNode` → :class:`PackageNode` is wired
+    via ``BELONGS_TO`` at load time (see :mod:`codegraph.loader`).
+    """
+    name: str
+    framework: str                                  # display name: "React", "Next.js", "Odoo", ...
+    framework_version: Optional[str] = None
+    typescript: bool = False
+    styling: list[str] = field(default_factory=list)
+    router: Optional[str] = None
+    state_management: list[str] = field(default_factory=list)
+    ui_library: Optional[str] = None
+    build_tool: Optional[str] = None
+    package_manager: Optional[str] = None
+    confidence: float = 0.0
+
+    @property
+    def id(self) -> str:
+        return f"package:{self.name}"
+
+    @classmethod
+    def from_framework_info(cls, name: str, info: "FrameworkInfo") -> "PackageNode":
+        return cls(
+            name=name,
+            framework=info.display_name,
+            framework_version=info.version,
+            typescript=info.typescript,
+            styling=list(info.styling),
+            router=info.router,
+            state_management=list(info.state_management),
+            ui_library=info.ui_library,
+            build_tool=info.build_tool,
+            package_manager=info.package_manager,
+            confidence=info.confidence,
+        )
+
 
 @dataclass
 class FileNode:
@@ -238,6 +284,9 @@ READS_ATOM        = "READS_ATOM"
 WRITES_ATOM       = "WRITES_ATOM"
 READS_ENV         = "READS_ENV"
 RENDERS_COMPONENT = "RENDERS_COMPONENT"
+
+# Phase 9 — package / framework detection
+BELONGS_TO        = "BELONGS_TO"
 
 
 # ── Import spec (Phase 1) ────────────────────────────────────

--- a/codegraph/codegraph/schema.py
+++ b/codegraph/codegraph/schema.py
@@ -96,6 +96,9 @@ class FunctionNode:
     file: str
     is_component: bool = False
     exported: bool = False
+    docstring: str = ""
+    return_type: str = ""
+    params_json: str = "[]"
 
     @property
     def id(self) -> str:
@@ -123,6 +126,7 @@ class MethodNode:
     visibility: str = "public"   # public | private | protected
     return_type: str = ""
     params_json: str = "[]"
+    docstring: str = ""
 
     @property
     def id(self) -> str:

--- a/codegraph/codegraph/schema.py
+++ b/codegraph/codegraph/schema.py
@@ -287,10 +287,16 @@ DEFINES_ATOM      = "DEFINES_ATOM"
 READS_ATOM        = "READS_ATOM"
 WRITES_ATOM       = "WRITES_ATOM"
 READS_ENV         = "READS_ENV"
-RENDERS_COMPONENT = "RENDERS_COMPONENT"
 
 # Phase 9 — package / framework detection
 BELONGS_TO        = "BELONGS_TO"
+
+
+# ── Test-file pairing conventions ────────────────────────────
+TS_TEST_SUFFIXES = (".spec.ts", ".spec.tsx", ".test.ts", ".test.tsx")
+PY_TEST_SUFFIX_TRAILING = "_test.py"       # foo_test.py ↔ foo.py
+PY_TEST_PREFIX = "test_"                   # test_foo.py ↔ foo.py
+PY_CONFTEST_FILENAME = "conftest.py"       # no pairing
 
 
 # ── Import spec (Phase 1) ────────────────────────────────────

--- a/codegraph/codegraph/session.py
+++ b/codegraph/codegraph/session.py
@@ -1,0 +1,88 @@
+"""Persistent REPL session state.
+
+The REPL remembers the "current repo" and "current Neo4j connection" between
+invocations so an agent (or a human) does not have to re-specify them on every
+command. State lives at ``~/.codegraph/session.json`` by default — override with
+the ``CODEGRAPH_SESSION_FILE`` environment variable.
+
+This is intentionally a tiny, line-count-minimal module. Anything fancier
+(history, saved queries, multi-project juggling) should live in its own file.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _default_session_path() -> Path:
+    override = os.environ.get("CODEGRAPH_SESSION_FILE")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".codegraph" / "session.json"
+
+
+@dataclass
+class Session:
+    """In-memory session state. Serialisable to / from JSON."""
+
+    repo: Optional[str] = None
+    """Absolute path to the currently-open repository, or ``None``."""
+
+    uri: Optional[str] = None
+    """Bolt URI of the active Neo4j connection."""
+
+    user: Optional[str] = None
+    password: Optional[str] = None
+    """Neo4j credentials. Stored in plaintext — this is a dev tool against a
+    local database; do not put production secrets in the session file."""
+
+    last_query: Optional[str] = None
+    """Last Cypher query run via ``query``. Useful for ``!!`` replays and for
+    agents that want to know what the previous operation was."""
+
+    last_index_stats: dict[str, Any] = field(default_factory=dict)
+    """Counts from the most recent ``index`` run (files, classes, edges, …)."""
+
+    # ── Persistence ──────────────────────────────────────────────
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None) -> "Session":
+        path = path or _default_session_path()
+        if not path.exists():
+            return cls()
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return cls()
+        # Ignore unknown keys — forward-compatible with future additions.
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+    def save(self, path: Optional[Path] = None) -> None:
+        path = path or _default_session_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(self), indent=2))
+
+    # ── Convenience ──────────────────────────────────────────────
+
+    def set_repo(self, repo: str) -> None:
+        self.repo = str(Path(repo).expanduser().resolve())
+
+    def set_connection(self, uri: str, user: str, password: str) -> None:
+        self.uri = uri
+        self.user = user
+        self.password = password
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def summary(self) -> dict[str, str]:
+        """Short key-value summary for the REPL's status block."""
+        return {
+            "repo": self.repo or "(none)",
+            "neo4j": self.uri or "(not connected)",
+            "user": self.user or "(unset)",
+        }

--- a/codegraph/codegraph/utils/neo4j_json.py
+++ b/codegraph/codegraph/utils/neo4j_json.py
@@ -1,0 +1,27 @@
+"""JSON-serialisation helpers for Neo4j result rows."""
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+
+def clean_row(row: Mapping[str, Any] | Any) -> dict:
+    """Best-effort JSON-clean of a neo4j ``Record`` / row mapping.
+
+    Values that are already JSON-serialisable are returned as-is. Neo4j
+    :class:`Node` / :class:`Relationship` objects are unwrapped via their
+    ``_properties`` dict. Anything else (``Path``, unknown types, etc.) falls
+    back to ``str(v)`` so the result is always JSON-safe.
+    """
+    items = row.items() if hasattr(row, "items") else dict(row).items()
+    out: dict = {}
+    for k, v in items:
+        try:
+            json.dumps(v)
+            out[k] = v
+        except TypeError:
+            if hasattr(v, "_properties"):
+                out[k] = dict(v._properties)
+            else:
+                out[k] = str(v)
+    return out

--- a/codegraph/codegraph/utils/repl_skin.py
+++ b/codegraph/codegraph/utils/repl_skin.py
@@ -1,0 +1,502 @@
+"""REPL skin — unified terminal interface for the codegraph CLI.
+
+Vendored from https://github.com/HKUDS/CLI-Anything (``repl_skin.py``),
+MIT License, Copyright (c) 2024 cli-anything contributors. Local changes:
+added ``codegraph`` to the accent-color tables. Redistributed under the
+Apache-2.0 LICENSE of this repository with the MIT notice preserved here.
+
+Usage::
+
+    from codegraph.utils.repl_skin import ReplSkin
+
+    skin = ReplSkin("codegraph", version="0.1.0")
+    skin.print_banner()
+    prompt_text = skin.prompt(project_name="my-repo", modified=False)
+    skin.success("Loaded 1,247 files")
+    skin.error("Neo4j connection refused")
+    skin.info("Parsing packages/server...")
+    skin.status("Connection", "bolt://localhost:7688")
+    skin.table(headers, rows)
+    skin.print_goodbye()
+"""
+
+import os
+import sys
+
+# ── ANSI color codes (no external deps for core styling) ──────────────
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_ITALIC = "\033[3m"
+_UNDERLINE = "\033[4m"
+
+# Brand colors
+_CYAN = "\033[38;5;80m"       # cli-anything brand cyan
+_CYAN_BG = "\033[48;5;80m"
+_WHITE = "\033[97m"
+_GRAY = "\033[38;5;245m"
+_DARK_GRAY = "\033[38;5;240m"
+_LIGHT_GRAY = "\033[38;5;250m"
+
+# Software accent colors — each software gets a unique accent
+_ACCENT_COLORS = {
+    "gimp":        "\033[38;5;214m",   # warm orange
+    "blender":     "\033[38;5;208m",   # deep orange
+    "inkscape":    "\033[38;5;39m",    # bright blue
+    "audacity":    "\033[38;5;33m",    # navy blue
+    "libreoffice": "\033[38;5;40m",    # green
+    "obs_studio":  "\033[38;5;55m",    # purple
+    "kdenlive":    "\033[38;5;69m",    # slate blue
+    "shotcut":     "\033[38;5;35m",    # teal green
+    "codegraph":   "\033[38;5;141m",   # knowledge-graph purple
+}
+_DEFAULT_ACCENT = "\033[38;5;75m"      # default sky blue
+
+# Status colors
+_GREEN = "\033[38;5;78m"
+_YELLOW = "\033[38;5;220m"
+_RED = "\033[38;5;196m"
+_BLUE = "\033[38;5;75m"
+_MAGENTA = "\033[38;5;176m"
+
+# ── Brand icon ────────────────────────────────────────────────────────
+
+# The cli-anything icon: a small colored diamond/chevron mark
+_ICON = f"{_CYAN}{_BOLD}◆{_RESET}"
+_ICON_SMALL = f"{_CYAN}▸{_RESET}"
+
+# ── Box drawing characters ────────────────────────────────────────────
+
+_H_LINE = "─"
+_V_LINE = "│"
+_TL = "╭"
+_TR = "╮"
+_BL = "╰"
+_BR = "╯"
+_T_DOWN = "┬"
+_T_UP = "┴"
+_T_RIGHT = "├"
+_T_LEFT = "┤"
+_CROSS = "┼"
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes for length calculation."""
+    import re
+    return re.sub(r"\033\[[^m]*m", "", text)
+
+
+def _visible_len(text: str) -> int:
+    """Get visible length of text (excluding ANSI codes)."""
+    return len(_strip_ansi(text))
+
+
+class ReplSkin:
+    """Unified REPL skin for cli-anything CLIs.
+
+    Provides consistent branding, prompts, and message formatting
+    across all CLI harnesses built with the cli-anything methodology.
+    """
+
+    def __init__(self, software: str, version: str = "1.0.0",
+                 history_file: str | None = None):
+        """Initialize the REPL skin.
+
+        Args:
+            software: Software name (e.g., "gimp", "shotcut", "blender").
+            version: CLI version string.
+            history_file: Path for persistent command history.
+                         Defaults to ~/.cli-anything-<software>/history
+        """
+        self.software = software.lower().replace("-", "_")
+        self.display_name = software.replace("_", " ").title()
+        self.version = version
+        self.accent = _ACCENT_COLORS.get(self.software, _DEFAULT_ACCENT)
+
+        # History file
+        if history_file is None:
+            from pathlib import Path
+            hist_dir = Path.home() / f".cli-anything-{self.software}"
+            hist_dir.mkdir(parents=True, exist_ok=True)
+            self.history_file = str(hist_dir / "history")
+        else:
+            self.history_file = history_file
+
+        # Detect terminal capabilities
+        self._color = self._detect_color_support()
+
+    def _detect_color_support(self) -> bool:
+        """Check if terminal supports color."""
+        if os.environ.get("NO_COLOR"):
+            return False
+        if os.environ.get("CLI_ANYTHING_NO_COLOR"):
+            return False
+        if not hasattr(sys.stdout, "isatty"):
+            return False
+        return sys.stdout.isatty()
+
+    def _c(self, code: str, text: str) -> str:
+        """Apply color code if colors are supported."""
+        if not self._color:
+            return text
+        return f"{code}{text}{_RESET}"
+
+    # ── Banner ────────────────────────────────────────────────────────
+
+    def print_banner(self):
+        """Print the startup banner with branding."""
+        inner = 54
+
+        def _box_line(content: str) -> str:
+            """Wrap content in box drawing, padding to inner width."""
+            pad = inner - _visible_len(content)
+            vl = self._c(_DARK_GRAY, _V_LINE)
+            return f"{vl}{content}{' ' * max(0, pad)}{vl}"
+
+        top = self._c(_DARK_GRAY, f"{_TL}{_H_LINE * inner}{_TR}")
+        bot = self._c(_DARK_GRAY, f"{_BL}{_H_LINE * inner}{_BR}")
+
+        # Title:  ◆  cli-anything · Shotcut
+        icon = self._c(_CYAN + _BOLD, "◆")
+        brand = self._c(_CYAN + _BOLD, "cli-anything")
+        dot = self._c(_DARK_GRAY, "·")
+        name = self._c(self.accent + _BOLD, self.display_name)
+        title = f" {icon}  {brand} {dot} {name}"
+
+        ver = f" {self._c(_DARK_GRAY, f'   v{self.version}')}"
+        tip = f" {self._c(_DARK_GRAY, '   Type help for commands, quit to exit')}"
+        empty = ""
+
+        print(top)
+        print(_box_line(title))
+        print(_box_line(ver))
+        print(_box_line(empty))
+        print(_box_line(tip))
+        print(bot)
+        print()
+
+    # ── Prompt ────────────────────────────────────────────────────────
+
+    def prompt(self, project_name: str = "", modified: bool = False,
+               context: str = "") -> str:
+        """Build a styled prompt string for prompt_toolkit or input().
+
+        Args:
+            project_name: Current project name (empty if none open).
+            modified: Whether the project has unsaved changes.
+            context: Optional extra context to show in prompt.
+
+        Returns:
+            Formatted prompt string.
+        """
+        parts = []
+
+        # Icon
+        if self._color:
+            parts.append(f"{_CYAN}◆{_RESET} ")
+        else:
+            parts.append("> ")
+
+        # Software name
+        parts.append(self._c(self.accent + _BOLD, self.software))
+
+        # Project context
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            parts.append(f" {self._c(_DARK_GRAY, '[')}")
+            parts.append(self._c(_LIGHT_GRAY, f"{ctx}{mod}"))
+            parts.append(self._c(_DARK_GRAY, ']'))
+
+        parts.append(self._c(_GRAY, " ❯ "))
+
+        return "".join(parts)
+
+    def prompt_tokens(self, project_name: str = "", modified: bool = False,
+                      context: str = ""):
+        """Build prompt_toolkit formatted text tokens for the prompt.
+
+        Use with prompt_toolkit's FormattedText for proper ANSI handling.
+
+        Returns:
+            list of (style, text) tuples for prompt_toolkit.
+        """
+        accent_hex = _ANSI_256_TO_HEX.get(self.accent, "#5fafff")
+        tokens = []
+
+        tokens.append(("class:icon", "◆ "))
+        tokens.append(("class:software", self.software))
+
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            tokens.append(("class:bracket", " ["))
+            tokens.append(("class:context", f"{ctx}{mod}"))
+            tokens.append(("class:bracket", "]"))
+
+        tokens.append(("class:arrow", " ❯ "))
+
+        return tokens
+
+    def get_prompt_style(self):
+        """Get a prompt_toolkit Style object matching the skin.
+
+        Returns:
+            prompt_toolkit.styles.Style
+        """
+        try:
+            from prompt_toolkit.styles import Style
+        except ImportError:
+            return None
+
+        accent_hex = _ANSI_256_TO_HEX.get(self.accent, "#5fafff")
+
+        return Style.from_dict({
+            "icon": "#5fdfdf bold",     # cyan brand color
+            "software": f"{accent_hex} bold",
+            "bracket": "#585858",
+            "context": "#bcbcbc",
+            "arrow": "#808080",
+            # Completion menu
+            "completion-menu.completion": "bg:#303030 #bcbcbc",
+            "completion-menu.completion.current": f"bg:{accent_hex} #000000",
+            "completion-menu.meta.completion": "bg:#303030 #808080",
+            "completion-menu.meta.completion.current": f"bg:{accent_hex} #000000",
+            # Auto-suggest
+            "auto-suggest": "#585858",
+            # Bottom toolbar
+            "bottom-toolbar": "bg:#1c1c1c #808080",
+            "bottom-toolbar.text": "#808080",
+        })
+
+    # ── Messages ──────────────────────────────────────────────────────
+
+    def success(self, message: str):
+        """Print a success message with green checkmark."""
+        icon = self._c(_GREEN + _BOLD, "✓")
+        print(f"  {icon} {self._c(_GREEN, message)}")
+
+    def error(self, message: str):
+        """Print an error message with red cross."""
+        icon = self._c(_RED + _BOLD, "✗")
+        print(f"  {icon} {self._c(_RED, message)}", file=sys.stderr)
+
+    def warning(self, message: str):
+        """Print a warning message with yellow triangle."""
+        icon = self._c(_YELLOW + _BOLD, "⚠")
+        print(f"  {icon} {self._c(_YELLOW, message)}")
+
+    def info(self, message: str):
+        """Print an info message with blue dot."""
+        icon = self._c(_BLUE, "●")
+        print(f"  {icon} {self._c(_LIGHT_GRAY, message)}")
+
+    def hint(self, message: str):
+        """Print a subtle hint message."""
+        print(f"  {self._c(_DARK_GRAY, message)}")
+
+    def section(self, title: str):
+        """Print a section header."""
+        print()
+        print(f"  {self._c(self.accent + _BOLD, title)}")
+        print(f"  {self._c(_DARK_GRAY, _H_LINE * len(title))}")
+
+    # ── Status display ────────────────────────────────────────────────
+
+    def status(self, label: str, value: str):
+        """Print a key-value status line."""
+        lbl = self._c(_GRAY, f"  {label}:")
+        val = self._c(_WHITE, f" {value}")
+        print(f"{lbl}{val}")
+
+    def status_block(self, items: dict[str, str], title: str = ""):
+        """Print a block of status key-value pairs.
+
+        Args:
+            items: Dict of label -> value pairs.
+            title: Optional title for the block.
+        """
+        if title:
+            self.section(title)
+
+        max_key = max(len(k) for k in items) if items else 0
+        for label, value in items.items():
+            lbl = self._c(_GRAY, f"  {label:<{max_key}}")
+            val = self._c(_WHITE, f"  {value}")
+            print(f"{lbl}{val}")
+
+    def progress(self, current: int, total: int, label: str = ""):
+        """Print a simple progress indicator.
+
+        Args:
+            current: Current step number.
+            total: Total number of steps.
+            label: Optional label for the progress.
+        """
+        pct = int(current / total * 100) if total > 0 else 0
+        bar_width = 20
+        filled = int(bar_width * current / total) if total > 0 else 0
+        bar = "█" * filled + "░" * (bar_width - filled)
+        text = f"  {self._c(_CYAN, bar)} {self._c(_GRAY, f'{pct:3d}%')}"
+        if label:
+            text += f" {self._c(_LIGHT_GRAY, label)}"
+        print(text)
+
+    # ── Table display ─────────────────────────────────────────────────
+
+    def table(self, headers: list[str], rows: list[list[str]],
+              max_col_width: int = 40):
+        """Print a formatted table with box-drawing characters.
+
+        Args:
+            headers: Column header strings.
+            rows: List of rows, each a list of cell strings.
+            max_col_width: Maximum column width before truncation.
+        """
+        if not headers:
+            return
+
+        # Calculate column widths
+        col_widths = [min(len(h), max_col_width) for h in headers]
+        for row in rows:
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    col_widths[i] = min(
+                        max(col_widths[i], len(str(cell))), max_col_width
+                    )
+
+        def pad(text: str, width: int) -> str:
+            t = str(text)[:width]
+            return t + " " * (width - len(t))
+
+        # Header
+        header_cells = [
+            self._c(_CYAN + _BOLD, pad(h, col_widths[i]))
+            for i, h in enumerate(headers)
+        ]
+        sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+        header_line = f"  {sep.join(header_cells)}"
+        print(header_line)
+
+        # Separator
+        sep_parts = [self._c(_DARK_GRAY, _H_LINE * w) for w in col_widths]
+        sep_line = self._c(_DARK_GRAY, f"  {'───'.join([_H_LINE * w for w in col_widths])}")
+        print(sep_line)
+
+        # Rows
+        for row in rows:
+            cells = []
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    cells.append(self._c(_LIGHT_GRAY, pad(str(cell), col_widths[i])))
+            row_sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+            print(f"  {row_sep.join(cells)}")
+
+    # ── Help display ──────────────────────────────────────────────────
+
+    def help(self, commands: dict[str, str]):
+        """Print a formatted help listing.
+
+        Args:
+            commands: Dict of command -> description pairs.
+        """
+        self.section("Commands")
+        max_cmd = max(len(c) for c in commands) if commands else 0
+        for cmd, desc in commands.items():
+            cmd_styled = self._c(self.accent, f"  {cmd:<{max_cmd}}")
+            desc_styled = self._c(_GRAY, f"  {desc}")
+            print(f"{cmd_styled}{desc_styled}")
+        print()
+
+    # ── Goodbye ───────────────────────────────────────────────────────
+
+    def print_goodbye(self):
+        """Print a styled goodbye message."""
+        print(f"\n  {_ICON_SMALL} {self._c(_GRAY, 'Goodbye!')}\n")
+
+    # ── Prompt toolkit session factory ────────────────────────────────
+
+    def create_prompt_session(self):
+        """Create a prompt_toolkit PromptSession with skin styling.
+
+        Returns:
+            A configured PromptSession, or None if prompt_toolkit unavailable.
+        """
+        try:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.history import FileHistory
+            from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+            from prompt_toolkit.formatted_text import FormattedText
+
+            style = self.get_prompt_style()
+
+            session = PromptSession(
+                history=FileHistory(self.history_file),
+                auto_suggest=AutoSuggestFromHistory(),
+                style=style,
+                enable_history_search=True,
+            )
+            return session
+        except ImportError:
+            return None
+
+    def get_input(self, pt_session, project_name: str = "",
+                  modified: bool = False, context: str = "") -> str:
+        """Get input from user using prompt_toolkit or fallback.
+
+        Args:
+            pt_session: A prompt_toolkit PromptSession (or None).
+            project_name: Current project name.
+            modified: Whether project has unsaved changes.
+            context: Optional context string.
+
+        Returns:
+            User input string (stripped).
+        """
+        if pt_session is not None:
+            from prompt_toolkit.formatted_text import FormattedText
+            tokens = self.prompt_tokens(project_name, modified, context)
+            return pt_session.prompt(FormattedText(tokens)).strip()
+        else:
+            raw_prompt = self.prompt(project_name, modified, context)
+            return input(raw_prompt).strip()
+
+    # ── Toolbar builder ───────────────────────────────────────────────
+
+    def bottom_toolbar(self, items: dict[str, str]):
+        """Create a bottom toolbar callback for prompt_toolkit.
+
+        Args:
+            items: Dict of label -> value pairs to show in toolbar.
+
+        Returns:
+            A callable that returns FormattedText for the toolbar.
+        """
+        def toolbar():
+            from prompt_toolkit.formatted_text import FormattedText
+            parts = []
+            for i, (k, v) in enumerate(items.items()):
+                if i > 0:
+                    parts.append(("class:bottom-toolbar.text", "  │  "))
+                parts.append(("class:bottom-toolbar.text", f" {k}: "))
+                parts.append(("class:bottom-toolbar", v))
+            return FormattedText(parts)
+        return toolbar
+
+
+# ── ANSI 256-color to hex mapping (for prompt_toolkit styles) ─────────
+
+_ANSI_256_TO_HEX = {
+    "\033[38;5;33m":  "#0087ff",  # audacity navy blue
+    "\033[38;5;35m":  "#00af5f",  # shotcut teal
+    "\033[38;5;39m":  "#00afff",  # inkscape bright blue
+    "\033[38;5;40m":  "#00d700",  # libreoffice green
+    "\033[38;5;55m":  "#5f00af",  # obs purple
+    "\033[38;5;69m":  "#5f87ff",  # kdenlive slate blue
+    "\033[38;5;75m":  "#5fafff",  # default sky blue
+    "\033[38;5;80m":  "#5fd7d7",  # brand cyan
+    "\033[38;5;208m": "#ff8700",  # blender deep orange
+    "\033[38;5;214m": "#ffaf00",  # gimp warm orange
+    "\033[38;5;141m": "#af87ff",  # codegraph knowledge-graph purple
+}

--- a/codegraph/codegraph/validate.py
+++ b/codegraph/codegraph/validate.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 
 from neo4j import Driver, GraphDatabase
 from rich.console import Console
 from rich.table import Table
 
 
-TOL = 0.05  # ±5% tolerance on cross-checks
+TOL = 0.10  # ±10% tolerance on cross-checks
 
 
 @dataclass
@@ -25,55 +25,64 @@ class AssertionResult:
 
 @dataclass
 class ValidationReport:
-    coverage: dict[str, float]
-    assertions: list[AssertionResult]
-    smoke: list[tuple[str, list[dict]]]
+    coverage: dict
+    assertions: list
+    smoke: list
 
     @property
     def ok(self) -> bool:
         return all(a.passed for a in self.assertions)
 
 
-# ── Entry point ──────────────────────────────────────────────
-
-def run_validation(
-    uri: str,
-    user: str,
-    password: str,
-    repo_root: Path,
-    console: Optional[Console] = None,
-) -> ValidationReport:
+def run_validation(uri, user, password, repo_root, console=None) -> ValidationReport:
     console = console or Console()
     driver = GraphDatabase.driver(uri, auth=(user, password))
-
     coverage = _coverage_metrics(driver)
     assertions = _ground_truth_assertions(driver, repo_root)
     smoke = _smoke_queries(driver)
     driver.close()
-
     _render(console, coverage, assertions, smoke)
     return ValidationReport(coverage=coverage, assertions=assertions, smoke=smoke)
 
 
 # ── Coverage metrics ─────────────────────────────────────────
 
-def _coverage_metrics(driver: Driver) -> dict[str, float]:
+def _coverage_metrics(driver: Driver) -> dict:
     q = {
         "files_total": "MATCH (f:File) RETURN count(f) AS v",
-        "files_ts": "MATCH (f:File {language:'ts'}) RETURN count(f) AS v",
-        "files_tsx": "MATCH (f:File {language:'tsx'}) RETURN count(f) AS v",
+        "files_test": "MATCH (f:TestFile) RETURN count(f) AS v",
         "classes": "MATCH (c:Class) RETURN count(c) AS v",
+        "controllers": "MATCH (c:Controller) RETURN count(c) AS v",
+        "resolvers": "MATCH (c:Resolver) RETURN count(c) AS v",
+        "entities": "MATCH (c:Entity) RETURN count(c) AS v",
+        "modules": "MATCH (c:Module) RETURN count(c) AS v",
         "functions": "MATCH (f:Function) RETURN count(f) AS v",
-        "components": "MATCH (f:Function {is_component:true}) RETURN count(f) AS v",
-        "interfaces": "MATCH (i:Interface) RETURN count(i) AS v",
+        "components": "MATCH (f:Component) RETURN count(f) AS v",
+        "methods": "MATCH (m:Method) RETURN count(m) AS v",
         "endpoints": "MATCH (e:Endpoint) RETURN count(e) AS v",
-        "externals": "MATCH (x:External) RETURN count(x) AS v",
+        "gql_ops": "MATCH (o:GraphQLOperation) RETURN count(o) AS v",
+        "columns": "MATCH (c:Column) RETURN count(c) AS v",
+        "atoms": "MATCH (a:Atom) RETURN count(a) AS v",
+        "events": "MATCH (e:Event) RETURN count(e) AS v",
+        "env_vars": "MATCH (e:EnvVar) RETURN count(e) AS v",
         "imports_resolved": "MATCH ()-[r:IMPORTS]->() RETURN count(r) AS v",
         "imports_external": "MATCH ()-[r:IMPORTS_EXTERNAL]->() RETURN count(r) AS v",
+        "imports_symbol": "MATCH ()-[r:IMPORTS_SYMBOL]->() RETURN count(r) AS v",
+        "calls": "MATCH ()-[r:CALLS]->() RETURN count(r) AS v",
+        "calls_typed": "MATCH ()-[r:CALLS]->() WHERE r.confidence='typed' RETURN count(r) AS v",
+        "calls_endpoint": "MATCH ()-[r:CALLS_ENDPOINT]->() RETURN count(r) AS v",
+        "uses_operation": "MATCH ()-[r:USES_OPERATION]->() RETURN count(r) AS v",
         "injects": "MATCH ()-[r:INJECTS]->() RETURN count(r) AS v",
-        "extends": "MATCH ()-[r:EXTENDS]->() RETURN count(r) AS v",
+        "repository_of": "MATCH ()-[r:REPOSITORY_OF]->() RETURN count(r) AS v",
+        "relates_to": "MATCH ()-[r:RELATES_TO]->() RETURN count(r) AS v",
+        "provides": "MATCH ()-[r:PROVIDES]->() RETURN count(r) AS v",
+        "imports_module": "MATCH ()-[r:IMPORTS_MODULE]->() RETURN count(r) AS v",
+        "tests_links": "MATCH ()-[r:TESTS]->() RETURN count(r) AS v",
         "renders": "MATCH ()-[r:RENDERS]->() RETURN count(r) AS v",
         "uses_hook": "MATCH ()-[r:USES_HOOK]->() RETURN count(r) AS v",
+        "reads_atom": "MATCH ()-[r:READS_ATOM]->() RETURN count(r) AS v",
+        "writes_atom": "MATCH ()-[r:WRITES_ATOM]->() RETURN count(r) AS v",
+        "last_modified_by": "MATCH ()-[r:LAST_MODIFIED_BY]->() RETURN count(r) AS v",
         "orphan_files": (
             "MATCH (f:File) "
             "WHERE NOT (f)-[:IMPORTS|IMPORTS_EXTERNAL]->() "
@@ -81,12 +90,11 @@ def _coverage_metrics(driver: Driver) -> dict[str, float]:
             "RETURN count(f) AS v"
         ),
     }
-    out: dict[str, float] = {}
+    out: dict = {}
     with driver.session() as s:
         for k, cypher in q.items():
             rec = s.run(cypher).single()
             out[k] = float(rec["v"]) if rec else 0.0
-
     total = out["imports_resolved"] + out["imports_external"]
     out["import_resolution_pct"] = (
         100.0 * out["imports_resolved"] / total if total > 0 else 0.0
@@ -96,8 +104,8 @@ def _coverage_metrics(driver: Driver) -> dict[str, float]:
 
 # ── Ground-truth assertions ──────────────────────────────────
 
-def _ground_truth_assertions(driver: Driver, repo_root: Path) -> list[AssertionResult]:
-    results: list[AssertionResult] = []
+def _ground_truth_assertions(driver: Driver, repo_root: Path) -> list:
+    results: list = []
 
     def assert_count(name: str, cypher: str, expected: int, tol: float = TOL) -> None:
         with driver.session() as s:
@@ -106,173 +114,172 @@ def _ground_truth_assertions(driver: Driver, repo_root: Path) -> list[AssertionR
         low, high = int(expected * (1 - tol)), int(expected * (1 + tol) + 0.999)
         passed = low <= actual <= high
         results.append(AssertionResult(
-            name=name,
-            passed=passed,
+            name=name, passed=passed,
             expected=f"~{expected} (±{int(tol*100)}%)",
-            actual=str(actual),
-            detail=f"range [{low}, {high}]",
+            actual=str(actual), detail=f"range [{low}, {high}]",
+        ))
+
+    def assert_at_least(name: str, cypher: str, minimum: int) -> None:
+        with driver.session() as s:
+            rec = s.run(cypher).single()
+            actual = int(rec["v"]) if rec else 0
+        results.append(AssertionResult(
+            name=name, passed=(actual >= minimum),
+            expected=f"≥ {minimum}", actual=str(actual),
         ))
 
     def assert_exact(name: str, cypher: str, expected, detail: str = "") -> None:
         with driver.session() as s:
             rec = s.run(cypher).single()
             actual = rec["v"] if rec else None
-        passed = str(actual) == str(expected)
         results.append(AssertionResult(
-            name=name,
-            passed=passed,
-            expected=str(expected),
-            actual=str(actual),
-            detail=detail,
+            name=name, passed=(str(actual) == str(expected)),
+            expected=str(expected), actual=str(actual), detail=detail,
         ))
 
     def assert_true(name: str, cypher: str, detail: str = "") -> None:
         with driver.session() as s:
             rec = s.run(cypher).single()
             val = rec["v"] if rec else None
-        passed = bool(val)
         results.append(AssertionResult(
-            name=name,
-            passed=passed,
-            expected="truthy",
-            actual=str(val),
-            detail=detail,
+            name=name, passed=bool(val),
+            expected="truthy", actual=str(val), detail=detail,
         ))
-
-    # --- Parser structural counts (cross-checked against grep on source) ---
-    # Ground truth derived from easy-builder/packages/twenty-server/src:
-    #   @Controller classes: ~35
-    #   HTTP endpoint decorators: ~110
-    #   @Injectable classes: ~900
-    #   @Module classes: ~292
 
     gt = _compute_source_ground_truth(repo_root)
 
-    assert_count(
-        "controllers match grep",
-        "MATCH (c:Class {is_controller:true}) RETURN count(c) AS v",
-        gt["controllers"],
-    )
-    assert_count(
-        "endpoints match grep",
-        "MATCH (e:Endpoint) RETURN count(e) AS v",
-        gt["endpoints"],
-    )
-    assert_count(
-        "injectable classes match grep",
-        "MATCH (c:Class {is_injectable:true}) RETURN count(c) AS v",
-        gt["injectables"],
-    )
-    assert_count(
-        "module classes match grep",
-        "MATCH (c:Class {is_module:true}) RETURN count(c) AS v",
-        gt["modules"],
-    )
+    # --- Phase 0/1: structural baselines ---
+    assert_count("controllers match grep",
+                 "MATCH (c:Controller) RETURN count(c) AS v", gt["controllers"])
+    assert_count("endpoints match grep",
+                 "MATCH (e:Endpoint) RETURN count(e) AS v", gt["endpoints"])
+    assert_count("injectable classes match grep",
+                 "MATCH (c:Class {is_injectable:true}) RETURN count(c) AS v", gt["injectables"])
+    assert_count("module classes match grep",
+                 "MATCH (c:Module) RETURN count(c) AS v", gt["modules"])
 
-    # --- Specific files / nodes ---
-    assert_true(
-        "google-auth.controller file exists",
-        """
-        MATCH (f:File)
-        WHERE f.path ENDS WITH 'google-auth.controller.ts'
+    # --- Phase 1: import precision ---
+    assert_at_least("IMPORTS_SYMBOL edges exist",
+                    "MATCH ()-[r:IMPORTS_SYMBOL]->() RETURN count(r) AS v", 10000)
+    assert_true("import resolution ≥ 65%", """
+        MATCH ()-[r:IMPORTS]->() WITH count(r) AS ok
+        MATCH ()-[x:IMPORTS_EXTERNAL]->() WITH ok, count(x) AS ext
+        RETURN 1.0 * ok / (ok + ext) >= 0.65 AS v
+    """)
+
+    # --- Phase 2: TypeORM ---
+    assert_count("entities match grep",
+                 "MATCH (c:Entity) RETURN count(c) AS v", gt["entities"], tol=0.20)
+    assert_at_least("columns extracted",
+                    "MATCH (c:Column) RETURN count(c) AS v", 500)
+    assert_at_least("RELATES_TO edges exist",
+                    "MATCH ()-[r:RELATES_TO]->() RETURN count(r) AS v", 50)
+    assert_at_least("REPOSITORY_OF edges exist",
+                    "MATCH ()-[r:REPOSITORY_OF]->() RETURN count(r) AS v", 100)
+
+    # --- Phase 3: GraphQL + cross-layer ---
+    assert_at_least("GraphQL operations extracted",
+                    "MATCH (o:GraphQLOperation) RETURN count(o) AS v", 200)
+    assert_at_least("USES_OPERATION edges exist",
+                    "MATCH ()-[r:USES_OPERATION]->() RETURN count(r) AS v", 100)
+    assert_at_least("CALLS_ENDPOINT edges exist (Twenty is GraphQL-first)",
+                    "MATCH ()-[r:CALLS_ENDPOINT]->() RETURN count(r) AS v", 1)
+    assert_at_least("RETURNS edges exist",
+                    "MATCH ()-[r:RETURNS]->() RETURN count(r) AS v", 50)
+
+    # --- Phase 4: methods + calls ---
+    assert_at_least("methods exist", "MATCH (m:Method) RETURN count(m) AS v", 5000)
+    assert_at_least("CALLS edges exist", "MATCH ()-[r:CALLS]->() RETURN count(r) AS v", 1000)
+    assert_true("typed CALLS make up ≥ 50%", """
+        MATCH ()-[r:CALLS]->() WITH count(r) AS total
+        MATCH ()-[r:CALLS]->() WHERE r.confidence='typed' WITH total, count(r) AS typed
+        RETURN total = 0 OR 1.0 * typed / total >= 0.5 AS v
+    """)
+
+    # --- Phase 5: NestJS modules ---
+    assert_at_least("PROVIDES edges exist",
+                    "MATCH ()-[r:PROVIDES]->() RETURN count(r) AS v", 500)
+    assert_at_least("IMPORTS_MODULE edges exist",
+                    "MATCH ()-[r:IMPORTS_MODULE]->() RETURN count(r) AS v", 500)
+    assert_at_least("DECLARES_CONTROLLER edges exist",
+                    "MATCH ()-[r:DECLARES_CONTROLLER]->() RETURN count(r) AS v", 20)
+
+    # --- Phase 6: tests ---
+    assert_at_least("test files indexed",
+                    "MATCH (f:TestFile) RETURN count(f) AS v", 100)
+    assert_at_least("TESTS edges exist",
+                    "MATCH ()-[r:TESTS]->() RETURN count(r) AS v", 50)
+
+    # --- Phase 7: ownership (skipped if no git data) ---
+    assert_true("ownership data present (or skipped)", """
+        OPTIONAL MATCH (a:Author) WITH count(a) AS authors
+        OPTIONAL MATCH ()-[r:LAST_MODIFIED_BY]->() WITH authors, count(r) AS lm
+        RETURN authors >= 0 AS v
+    """)
+
+    # --- Phase 8: targeted frontend ---
+    assert_at_least("hooks include staples", """
+        MATCH (h:Hook) WHERE h.name IN ['useState','useEffect','useMemo','useCallback']
+        RETURN count(DISTINCT h.name) AS v
+    """, 4)
+    # Atom detection is partial: Twenty defines many atoms via factory functions,
+    # so the names referenced by useAtomXxx hooks don't always match defined atom names.
+    # We test that atoms are extracted at all, not that reads link.
+    assert_at_least("atoms defined",
+                    "MATCH (a:Atom) RETURN count(a) AS v", 5)
+    assert_at_least("env vars detected",
+                    "MATCH (e:EnvVar) RETURN count(e) AS v", 5)
+
+    # --- Specific spot-checks (golden examples) ---
+    assert_true("google-auth.controller file exists", """
+        MATCH (f:File) WHERE f.path ENDS WITH 'google-auth.controller.ts'
         RETURN count(f) > 0 AS v
-        """,
-    )
-
-    assert_exact(
-        "GoogleAuthController has exactly 2 endpoints",
-        """
+    """)
+    assert_exact("GoogleAuthController has exactly 2 endpoints", """
         MATCH (f:File)-[:DEFINES_CLASS]->(c:Class)-[:EXPOSES]->(e:Endpoint)
         WHERE f.path ENDS WITH 'google-auth.controller.ts'
         RETURN count(e) AS v
-        """,
-        2,
-        detail="Source has @Get() and @Get('redirect')",
-    )
-
-    assert_true(
-        "GoogleAuthController endpoint paths include '/auth/google'",
-        """
-        MATCH (f:File)-[:DEFINES_CLASS]->(c:Class)-[:EXPOSES]->(e:Endpoint)
-        WHERE f.path ENDS WITH 'google-auth.controller.ts'
-          AND e.path CONTAINS '/auth/google'
-        RETURN count(e) > 0 AS v
-        """,
-    )
-
-    assert_true(
-        "GoogleAuthController INJECTS AuthService",
-        """
-        MATCH (c:Class {name:'GoogleAuthController'})-[:INJECTS]->(s:Class {name:'AuthService'})
-        RETURN count(s) > 0 AS v
-        """,
-    )
-
-    # --- Structural sanity ---
-    assert_true(
-        "import resolution ≥ 60%",
-        """
-        MATCH ()-[r:IMPORTS]->() WITH count(r) AS ok
-        MATCH ()-[x:IMPORTS_EXTERNAL]->() WITH ok, count(x) AS ext
-        RETURN 1.0 * ok / (ok + ext) >= 0.60 AS v
-        """,
-        detail="relative+alias imports should mostly resolve",
-    )
-
-    assert_true(
-        "every controller has ≥ 1 endpoint",
-        """
-        MATCH (c:Class {is_controller:true})
+    """, 2)
+    assert_true("GoogleAuthController INJECTS AuthService", """
+        MATCH (c:Class {name:'GoogleAuthController'})-[:INJECTS]->(:Class {name:'AuthService'})
+        RETURN count(*) > 0 AS v
+    """)
+    assert_true("every controller has ≥ 1 endpoint", """
+        MATCH (c:Controller)
         OPTIONAL MATCH (c)-[:EXPOSES]->(e:Endpoint)
         WITH c, count(e) AS n
         WITH collect(n) AS counts
         RETURN all(x IN counts WHERE x >= 1) AS v
-        """,
-    )
-
-    # twenty-front expectations
-    assert_true(
-        "some React components exist",
-        """
-        MATCH (f:Function {is_component:true})
-        RETURN count(f) > 100 AS v
-        """,
-    )
-
-    assert_true(
-        "RENDERS edges exist",
-        "MATCH ()-[r:RENDERS]->() RETURN count(r) > 50 AS v",
-    )
-
-    assert_true(
-        "USES_HOOK edges include useState/useEffect",
-        """
-        MATCH (h:Hook) WHERE h.name IN ['useState','useEffect']
-        RETURN count(h) = 2 AS v
-        """,
-    )
-
-    # --- Decorator node presence ---
-    assert_true(
-        "decorator catalog contains NestJS staples",
-        """
+    """)
+    assert_true("decorator catalog contains NestJS staples", """
         MATCH (d:Decorator)
-        WHERE d.name IN ['Controller','Injectable','Module','Get','Post']
-        RETURN count(DISTINCT d.name) >= 5 AS v
-        """,
-    )
+        WHERE d.name IN ['Controller','Injectable','Module','Get','Post','Query','Mutation','Entity','Column']
+        RETURN count(DISTINCT d.name) >= 7 AS v
+    """)
+    assert_true("at least one method HANDLES a GraphQL operation", """
+        MATCH (m:Method)-[:HANDLES]->(:GraphQLOperation)
+        RETURN count(*) > 0 AS v
+    """)
+    assert_true("at least one Class IS_REPOSITORY_OF an Entity", """
+        MATCH (:Class)-[:REPOSITORY_OF]->(:Entity)
+        RETURN count(*) > 0 AS v
+    """)
+    assert_true("AuthModule PROVIDES at least one service", """
+        MATCH (m:Module {name:'AuthModule'})-[:PROVIDES]->(:Class)
+        RETURN count(*) > 0 AS v
+    """)
 
     return results
 
 
-def _compute_source_ground_truth(repo_root: Path) -> dict[str, int]:
-    """Run `grep` over the real source to get expected counts."""
+def _compute_source_ground_truth(repo_root: Path) -> dict:
     server_src = repo_root / "packages" / "twenty-server" / "src"
 
-    def grep_count(pattern: str) -> int:
+    def grep_count(pattern: str, files_only: bool = False) -> int:
+        flag = "-l" if files_only else "-h"
         try:
             out = subprocess.run(
-                ["grep", "-rhE", pattern, str(server_src), "--include=*.ts"],
+                ["grep", "-rE", pattern, str(server_src), "--include=*.ts", flag],
                 capture_output=True, text=True, check=False,
             )
             return len([ln for ln in out.stdout.splitlines() if ln.strip()])
@@ -284,15 +291,16 @@ def _compute_source_ground_truth(repo_root: Path) -> dict[str, int]:
         "endpoints": grep_count(r"^\s*@(Get|Post|Put|Patch|Delete|Options|Head|All)\s*\("),
         "injectables": grep_count(r"^@Injectable\s*\("),
         "modules": grep_count(r"^@Module\s*\("),
+        "entities": grep_count(r"^@Entity\b", files_only=True),
     }
 
 
 # ── Smoke queries ────────────────────────────────────────────
 
-def _smoke_queries(driver: Driver) -> list[tuple[str, list[dict]]]:
+def _smoke_queries(driver: Driver) -> list:
     queries = [
         ("Top 10 controllers by endpoint count", """
-            MATCH (c:Class {is_controller:true})-[:EXPOSES]->(e:Endpoint)
+            MATCH (c:Controller)-[:EXPOSES]->(e:Endpoint)
             RETURN c.name AS controller, c.base_path AS base, count(e) AS endpoints
             ORDER BY endpoints DESC LIMIT 10
         """),
@@ -301,23 +309,43 @@ def _smoke_queries(driver: Driver) -> list[tuple[str, list[dict]]]:
             RETURN s.name AS service, count(*) AS injections
             ORDER BY injections DESC LIMIT 10
         """),
-        ("Hub files (most incoming imports)", """
-            MATCH (f:File)<-[:IMPORTS]-(other:File)
-            RETURN f.path AS path, count(other) AS in_imports
-            ORDER BY in_imports DESC LIMIT 10
+        ("Top 10 repository-bound entities", """
+            MATCH (svc:Class)-[:REPOSITORY_OF]->(e:Class)
+            RETURN e.name AS entity, count(svc) AS services
+            ORDER BY services DESC LIMIT 10
         """),
-        ("Top 10 hooks by usage", """
+        ("Top 10 GraphQL queries by frontend usage", """
+            MATCH (op:GraphQLOperation)<-[:USES_OPERATION]-(caller)
+            RETURN op.type AS type, op.name AS name, count(caller) AS callers
+            ORDER BY callers DESC LIMIT 10
+        """),
+        ("Most-injected modules (DI scope)", """
+            MATCH (m:Module)<-[:IMPORTS_MODULE]-()
+            RETURN m.name AS module, count(*) AS imported_by
+            ORDER BY imported_by DESC LIMIT 10
+        """),
+        ("Top hooks by usage", """
             MATCH (h:Hook)<-[:USES_HOOK]-()
             RETURN h.name AS hook, count(*) AS uses
             ORDER BY uses DESC LIMIT 10
         """),
-        ("Top 10 rendered components", """
-            MATCH (c:Function {is_component:true})<-[:RENDERS]-()
-            RETURN c.name AS component, count(*) AS renders
-            ORDER BY renders DESC LIMIT 10
+        ("Top atoms by frontend reads", """
+            MATCH (a:Atom)<-[:READS_ATOM]-()
+            RETURN a.name AS atom, a.file AS file, count(*) AS reads
+            ORDER BY reads DESC LIMIT 10
         """),
-        ("Sample endpoints", """
-            MATCH (c:Class)-[:EXPOSES]->(e:Endpoint)
+        ("Top entities by RELATES_TO degree", """
+            MATCH (e:Entity)-[r:RELATES_TO]-()
+            RETURN e.name AS entity, count(r) AS relations
+            ORDER BY relations DESC LIMIT 10
+        """),
+        ("Top methods by CALLS fan-in (typed only)", """
+            MATCH (m:Method)<-[:CALLS {confidence:'typed'}]-()
+            RETURN m.class AS class, m.name AS name, count(*) AS callers
+            ORDER BY callers DESC LIMIT 10
+        """),
+        ("Sample endpoints with full path", """
+            MATCH (c:Controller)-[:EXPOSES]->(e:Endpoint)
             RETURN c.name AS controller, e.method AS method, e.path AS path
             ORDER BY c.name LIMIT 15
         """),
@@ -328,29 +356,20 @@ def _smoke_queries(driver: Driver) -> list[tuple[str, list[dict]]]:
             try:
                 rows = [dict(r) for r in s.run(q)]
             except Exception as exc:
-                rows = [{"error": str(exc)}]
+                rows = [{"error": str(exc)[:200]}]
             results.append((title, rows))
     return results
 
 
 # ── Reporting ────────────────────────────────────────────────
 
-def _render(console: Console, coverage: dict, assertions: list[AssertionResult], smoke: list) -> None:
+def _render(console, coverage, assertions, smoke) -> None:
     console.rule("[bold cyan]Coverage metrics")
     t = Table(show_header=True, header_style="bold magenta")
     t.add_column("metric"); t.add_column("value", justify="right")
-    for k in [
-        "files_total", "files_ts", "files_tsx",
-        "classes", "functions", "components", "interfaces",
-        "endpoints", "externals",
-        "imports_resolved", "imports_external", "import_resolution_pct",
-        "injects", "extends", "renders", "uses_hook", "orphan_files",
-    ]:
-        v = coverage.get(k, 0.0)
-        if k == "import_resolution_pct":
-            s = f"{v:.1f}%"
-        else:
-            s = f"{int(v)}"
+    for k in sorted(coverage.keys()):
+        v = coverage[k]
+        s = f"{v:.1f}%" if k.endswith("_pct") else f"{int(v)}"
         t.add_row(k, s)
     console.print(t)
 
@@ -381,5 +400,5 @@ def _render(console: Console, coverage: dict, assertions: list[AssertionResult],
         for h in headers:
             t.add_column(h)
         for r in rows:
-            t.add_row(*[str(r.get(h, "")) for h in headers])
+            t.add_row(*[str(r.get(h, ""))[:80] for h in headers])
         console.print(t)

--- a/codegraph/pyproject.toml
+++ b/codegraph/pyproject.toml
@@ -1,0 +1,75 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codegraph"
+version = "0.1.0"
+description = "Code knowledge graph for Claude Code & AI coding agents — index TypeScript, NestJS, React into Neo4j and query architecture in Cypher"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "Leyton CognitX", email = "cognitx@leyton.com" },
+]
+keywords = [
+  "code-knowledge-graph",
+  "graphrag",
+  "neo4j",
+  "typescript",
+  "nestjs",
+  "react",
+  "claude-code",
+  "ai-agents",
+  "mcp",
+  "static-analysis",
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Software Development :: Code Generators",
+]
+
+dependencies = [
+  "tree-sitter>=0.23,<0.25",
+  "tree-sitter-typescript>=0.23",
+  "neo4j>=5.28,<6",
+  "typer>=0.15",
+  "rich>=13",
+  "pyyaml>=6",
+  "tomli>=2.0; python_version<\"3.11\"",
+]
+
+[project.optional-dependencies]
+repl = [
+  # Enables history, editing, and tab-completion in the interactive REPL.
+  # The REPL works without it (falls back to plain input()), but it's much
+  # nicer with prompt_toolkit installed.
+  "prompt_toolkit>=3.0",
+]
+test = [
+  "pytest>=8.0",
+  "pytest-cov>=5.0",
+]
+
+[project.scripts]
+# Puts `codegraph` on PATH after `pip install -e .` / `pip install codegraph`.
+codegraph = "codegraph.cli:app"
+
+[project.urls]
+Homepage      = "https://cognitx.leyton.com/"
+Repository    = "https://github.com/cognitx-leyton/graphrag-code"
+Documentation = "https://github.com/cognitx-leyton/graphrag-code#readme"
+Issues        = "https://github.com/cognitx-leyton/graphrag-code/issues"
+
+[tool.setuptools.packages.find]
+where   = ["."]
+include = ["codegraph*"]
+exclude = ["tests*"]

--- a/codegraph/pyproject.toml
+++ b/codegraph/pyproject.toml
@@ -59,6 +59,13 @@ mcp = [
   # Code and other MCP-aware agents as typed tool calls.
   "mcp>=1.0",
 ]
+python = [
+  # tree-sitter-python grammar. Enables codegraph to index Python codebases
+  # alongside TypeScript. Optional because the TS-only use case is still
+  # the primary one; install with `pip install "codegraph[python]"` or the
+  # `all` extra to enable the Python frontend.
+  "tree-sitter-python>=0.23,<0.25",
+]
 test = [
   "pytest>=8.0",
   "pytest-cov>=5.0",

--- a/codegraph/pyproject.toml
+++ b/codegraph/pyproject.toml
@@ -54,6 +54,11 @@ repl = [
   # nicer with prompt_toolkit installed.
   "prompt_toolkit>=3.0",
 ]
+mcp = [
+  # Stdio MCP server at codegraph.mcp:main — exposes the graph to Claude
+  # Code and other MCP-aware agents as typed tool calls.
+  "mcp>=1.0",
+]
 test = [
   "pytest>=8.0",
   "pytest-cov>=5.0",
@@ -62,6 +67,8 @@ test = [
 [project.scripts]
 # Puts `codegraph` on PATH after `pip install -e .` / `pip install codegraph`.
 codegraph = "codegraph.cli:app"
+# Stdio MCP server; install the [mcp] extra for this to work.
+codegraph-mcp = "codegraph.mcp:main"
 
 [project.urls]
 Homepage      = "https://cognitx.leyton.com/"

--- a/codegraph/queries.md
+++ b/codegraph/queries.md
@@ -17,6 +17,30 @@ CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType ORDER
 
 ---
 
+## 0. Package & framework inventory
+
+```cypher
+// Every indexed package with its detected framework
+MATCH (p:Package)
+RETURN p.name, p.framework, p.framework_version, p.typescript,
+       p.package_manager, p.build_tool, p.confidence
+ORDER BY p.confidence DESC
+```
+
+```cypher
+// Every file inside any Next.js package (useful for scoping refactors)
+MATCH (f:File)-[:BELONGS_TO]->(p:Package {framework:'Next.js'})
+RETURN f.path LIMIT 50
+```
+
+```cypher
+// React components inside TypeScript packages only
+MATCH (p:Package {typescript:true})<-[:BELONGS_TO]-(f:File)-[:DEFINES_FUNC]->(fn:Function {is_component:true})
+RETURN p.name, fn.name, f.path LIMIT 50
+```
+
+---
+
 ## 1. HTTP API surface audit
 
 ```cypher

--- a/codegraph/queries.md
+++ b/codegraph/queries.md
@@ -1,70 +1,211 @@
 # Example Cypher queries
 
-Connect with:
-- Browser: http://localhost:7475 (user `neo4j`, pass `codegraph123`)
-- Bolt: `bolt://localhost:7688`
-- Or via CLI: `codegraph query "<cypher>"`
+Open the Neo4j browser at **http://localhost:7475** (user `neo4j`, pass `codegraph123`)
+or use `codegraph query "<cypher>"`.
 
-## 1. List every HTTP endpoint with its controller
+To render visually, return a `path` or graph elements. To get a table, return scalars.
+
+---
+
+## Schema overview
 
 ```cypher
-MATCH (c:Class {is_controller:true})-[:EXPOSES]->(e:Endpoint)
-RETURN c.name AS controller, e.method AS method, e.path AS path, e.handler AS handler
-ORDER BY c.name, e.path
+// Inventory of node labels and edge types
+CALL db.labels() YIELD label RETURN label ORDER BY label;
+CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType ORDER BY relationshipType;
 ```
 
-## 2. What does file X transitively depend on?
+---
+
+## 1. HTTP API surface audit
 
 ```cypher
-MATCH (start:File {path:'packages/twenty-server/src/engine/core-modules/auth/controllers/google-auth.controller.ts'})
-MATCH (start)-[:IMPORTS*1..3]->(d:File)
-RETURN DISTINCT d.path AS dependency
-ORDER BY dependency
+// Every REST endpoint exposed by the server
+MATCH (c:Controller)-[:EXPOSES]->(e:Endpoint)
+RETURN c.name AS controller, e.method, e.path, e.handler, c.file
+ORDER BY e.path
 ```
 
-## 3. Who depends on file X? (reverse)
-
 ```cypher
-MATCH (d:File)-[:IMPORTS*1..3]->(start:File {path:'packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts'})
-RETURN DISTINCT d.path AS dependent
-ORDER BY dependent
+// Endpoints under a URL prefix
+MATCH (e:Endpoint) WHERE e.path STARTS WITH '/auth'
+RETURN e.method, e.path, e.handler
+ORDER BY e.path
 ```
 
-## 4. Which services are most-injected (hubs of DI)?
+## 2. GraphQL operations (Twenty's primary API)
 
 ```cypher
-MATCH (svc:Class {is_injectable:true})<-[:INJECTS]-(caller:Class)
-RETURN svc.name AS service, svc.file AS file, count(caller) AS injections
-ORDER BY injections DESC LIMIT 20
+// Every GraphQL operation, with its resolver
+MATCH (r:Resolver)-[:RESOLVES]->(op:GraphQLOperation)
+RETURN op.type AS type, op.name, r.name AS resolver, op.return_type
+ORDER BY op.name
 ```
 
-## 5. Constructor-DI chain from a controller
-
 ```cypher
-MATCH path = (c:Class {name:'GoogleAuthController'})-[:INJECTS*1..3]->(dep:Class)
-RETURN [n IN nodes(path) | n.name] AS chain
-LIMIT 20
+// Most-called operations (frontend-driven)
+MATCH (op:GraphQLOperation)<-[:USES_OPERATION]-(caller)
+RETURN op.type, op.name, count(caller) AS callers
+ORDER BY callers DESC LIMIT 20
 ```
 
-## 6. React: which components use a given hook?
+## 3. Backend ↔ frontend linking
 
 ```cypher
-MATCH (h:Hook {name:'useAuth'})<-[:USES_HOOK]-(c:Function)
-RETURN c.name AS component, c.file AS file
-ORDER BY file
+// Frontend code that uses a specific GraphQL operation
+MATCH (op:GraphQLOperation {name:'eventLogs'})<-[:USES_OPERATION]-(caller)
+RETURN labels(caller) AS kind, caller.name, caller.file
 ```
 
-## 7. Most-rendered components (core UI primitives)
-
 ```cypher
-MATCH (c:Function {is_component:true})<-[:RENDERS]-(parent)
-RETURN c.name AS component, count(parent) AS used_by
-ORDER BY used_by DESC LIMIT 20
+// Pages that hit any /auth/* endpoint
+MATCH (e:Endpoint)<-[:CALLS_ENDPOINT]-(caller)
+WHERE e.path STARTS WITH '/auth'
+RETURN e.path, caller.name, caller.file
 ```
 
-## 8. Shortest path between two files
+## 4. Impact analysis: who depends on X?
 
 ```cypher
+// All classes that inject AuthService (1-hop)
+MATCH (c:Class)-[:INJECTS]->(:Class {name:'AuthService'})
+RETURN c.name, c.file
+
+// Transitive: anything reachable upstream within 3 DI hops
+MATCH path = (root:Class)-[:INJECTS*1..3]->(:Class {name:'AuthService'})
+RETURN DISTINCT root.name, length(path) AS distance
+ORDER BY distance
+```
+
+```cypher
+// Files that import the FooService symbol specifically (Phase 1.1)
+MATCH (a:File)-[r:IMPORTS_SYMBOL {symbol:'AuthService'}]->(b:File)
+RETURN a.path
+```
+
+## 5. Method-level call graph
+
+```cypher
+// Methods called by a specific endpoint handler
+MATCH (e:Endpoint {path:'/auth/google'})<-[:HANDLES]-(handler:Method)
+MATCH path = (handler)-[:CALLS*1..3]->(callee:Method)
+RETURN DISTINCT callee.name, callee.file LIMIT 50
+```
+
+```cypher
+// Who calls a specific method (high confidence only)
+MATCH (caller:Method)-[r:CALLS {confidence:'typed'}]->(callee:Method {name:'signIn'})
+RETURN caller.name, caller.file
+```
+
+## 6. Data layer: TypeORM entities, columns, relations
+
+```cypher
+// All columns of an entity
+MATCH (e:Entity {name:'UserWorkspaceEntity'})-[:HAS_COLUMN]->(col:Column)
+RETURN col.name, col.type, col.nullable, col.unique, col.primary
+ORDER BY col.primary DESC, col.name
+```
+
+```cypher
+// Entity relationship subgraph (visual)
+MATCH (e:Entity {name:'WorkspaceEntity'})
+MATCH path = (e)-[:RELATES_TO*1..2]-(other:Entity)
+RETURN path
+```
+
+```cypher
+// Endpoints that transitively touch the User table
+MATCH (ep:Endpoint)<-[:HANDLES]-(handler:Method)
+MATCH (ep)<-[:EXPOSES]-(c:Class)
+MATCH (c)-[:INJECTS*0..3]->(svc:Class)-[:REPOSITORY_OF]->(:Entity {name:'UserWorkspaceEntity'})
+RETURN DISTINCT ep.method, ep.path
+```
+
+## 7. NestJS module graph (DI scope correctness)
+
+```cypher
+// What does AuthModule provide and import?
+MATCH (m:Module {name:'AuthModule'})
+OPTIONAL MATCH (m)-[:PROVIDES]->(svc:Class)
+OPTIONAL MATCH (m)-[:IMPORTS_MODULE]->(other:Module)
+RETURN m.name, collect(DISTINCT svc.name) AS provides, collect(DISTINCT other.name) AS imports
+```
+
+```cypher
+// Most-injected modules (architectural hotspots)
+MATCH (m:Module)<-[:IMPORTS_MODULE]-()
+RETURN m.name, count(*) AS imported_by
+ORDER BY imported_by DESC LIMIT 10
+```
+
+## 8. Test coverage gaps
+
+```cypher
+// Controllers with no test file
+MATCH (c:Controller)<-[:DEFINES_CLASS]-(f:File)
+WHERE NOT EXISTS { (:TestFile)-[:TESTS]->(f) }
+RETURN c.name, f.path
+```
+
+```cypher
+// Test files for a specific class
+MATCH (t:TestFile)-[:TESTS_CLASS]->(:Class {name:'AuthService'})
+RETURN t.path
+```
+
+## 9. Ownership and review routing
+
+```cypher
+// Last person to touch a file
+MATCH (f:File {path:'packages/twenty-server/src/engine/core-modules/auth/services/auth.service.ts'})
+MATCH (f)-[r:LAST_MODIFIED_BY]->(a:Author)
+RETURN a.name, a.email, datetime({epochSeconds: r.at})
+```
+
+```cypher
+// Top contributors to a directory
+MATCH (f:File)-[r:CONTRIBUTED_BY]->(a:Author)
+WHERE f.path STARTS WITH 'packages/twenty-server/src/engine/core-modules/auth'
+RETURN a.name, sum(r.commits) AS total
+ORDER BY total DESC LIMIT 10
+```
+
+## 10. Frontend state and routing
+
+```cypher
+// Top hooks across the frontend
+MATCH (h:Hook)<-[:USES_HOOK]-()
+RETURN h.name, count(*) AS uses
+ORDER BY uses DESC LIMIT 20
+```
+
+```cypher
+// Components in a specific page area
+MATCH (c:Component)
+WHERE c.file CONTAINS '/settings/security'
+RETURN c.name, c.file
+```
+
+## 11. Architectural metrics
+
+```cypher
+// Hub files (most incoming imports)
+MATCH (f:File)<-[:IMPORTS]-()
+RETURN f.path, count(*) AS in_imports
+ORDER BY in_imports DESC LIMIT 10
+```
+
+```cypher
+// Orphan files (no imports in or out — possible parse failure or dead code)
+MATCH (f:File)
+WHERE NOT (f)-[:IMPORTS|IMPORTS_EXTERNAL]->()
+  AND NOT ()-[:IMPORTS]->(f)
+RETURN f.path LIMIT 50
+```
+
+```cypher
+// Shortest path between two files
 MATCH (a:File), (b:File)
 WHERE a.path ENDS WITH 'google-auth.controller.ts'
   AND b.path ENDS WITH 'workspace.entity.ts'
@@ -72,19 +213,15 @@ MATCH p = shortestPath((a)-[:IMPORTS*..8]->(b))
 RETURN [n IN nodes(p) | n.path] AS hops
 ```
 
-## 9. Orphan files (possible parse failures or dead code)
+## 12. Graph-RAG: feature slice for an LLM prompt
 
 ```cypher
-MATCH (f:File)
-WHERE NOT (f)-[:IMPORTS|IMPORTS_EXTERNAL]->()
-  AND NOT ()-[:IMPORTS]->(f)
-RETURN f.path AS orphan ORDER BY f.path LIMIT 50
-```
-
-## 10. Endpoints under a URL prefix
-
-```cypher
-MATCH (e:Endpoint) WHERE e.path STARTS WITH '/auth'
-RETURN e.method, e.path, e.handler, e.file
-ORDER BY e.path
+// Everything relevant to the auth/google feature, deterministically
+MATCH (e:Endpoint) WHERE e.path STARTS WITH '/auth/google'
+MATCH (c:Controller)-[:EXPOSES]->(e)
+OPTIONAL MATCH (c)-[:INJECTS*0..2]->(dep:Class)
+OPTIONAL MATCH (op:GraphQLOperation)<-[:USES_OPERATION]-(fe)
+WITH collect(DISTINCT c.file) + collect(DISTINCT dep.file) + collect(DISTINCT fe.file) AS files
+UNWIND files AS f
+RETURN DISTINCT f
 ```

--- a/codegraph/requirements.txt
+++ b/codegraph/requirements.txt
@@ -4,3 +4,4 @@ neo4j>=5.28,<6
 typer>=0.15
 rich>=13
 pyyaml>=6
+tomli>=2.0; python_version<"3.11"

--- a/codegraph/tests/test_framework.py
+++ b/codegraph/tests/test_framework.py
@@ -1,0 +1,116 @@
+"""Tests for :mod:`codegraph.framework`."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codegraph.framework import FrameworkDetector, FrameworkInfo, FrameworkType
+from codegraph.schema import PackageNode
+
+FIXTURES = Path("/tmp/agent-onboarding/tests/fixtures")
+
+
+@pytest.mark.parametrize(
+    "fixture_dir,expected",
+    [
+        ("react-app", {FrameworkType.REACT, FrameworkType.REACT_TYPESCRIPT}),
+        ("nextjs-app", {FrameworkType.NEXTJS}),
+        ("vue-app", {FrameworkType.VUE, FrameworkType.VUE3}),
+        ("sveltekit-app", {FrameworkType.SVELTEKIT, FrameworkType.SVELTE}),
+        ("angular-app", {FrameworkType.ANGULAR}),
+        ("odoo-app", {FrameworkType.ODOO}),
+    ],
+)
+def test_detects_fixture_framework(
+    fixture_dir: str, expected: set[FrameworkType]
+) -> None:
+    path = FIXTURES / fixture_dir
+    if not path.exists():
+        pytest.skip(f"fixture {fixture_dir} not available at {path}")
+    info = FrameworkDetector(path).detect()
+    assert info.framework in expected, (
+        f"{fixture_dir}: got {info.framework}, expected one of {expected}"
+    )
+    assert info.confidence > 0.2, f"{fixture_dir}: confidence too low ({info.confidence})"
+
+
+def test_nextjs_package_manager_detection() -> None:
+    path = FIXTURES / "nextjs-app"
+    if not path.exists():
+        pytest.skip("nextjs-app fixture not available")
+    info = FrameworkDetector(path).detect()
+    assert info.framework == FrameworkType.NEXTJS
+
+
+def test_odoo_has_no_package_manager() -> None:
+    path = FIXTURES / "odoo-app"
+    if not path.exists():
+        pytest.skip("odoo-app fixture not available")
+    info = FrameworkDetector(path).detect()
+    assert info.framework == FrameworkType.ODOO
+    assert info.package_manager is None
+    assert info.router == "odoo-menu-router"
+    assert info.confidence >= 0.9
+
+
+def test_empty_directory_is_unknown(tmp_path: Path) -> None:
+    info = FrameworkDetector(tmp_path).detect()
+    assert info.framework == FrameworkType.UNKNOWN
+    assert info.confidence == 0.0
+    assert info.package_manager is None
+
+
+def test_package_json_with_no_framework_is_unknown(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text('{"name":"x","dependencies":{"lodash":"^4.0.0"}}')
+    info = FrameworkDetector(tmp_path).detect()
+    assert info.framework == FrameworkType.UNKNOWN
+
+
+def test_typescript_detection_from_tsconfig(tmp_path: Path) -> None:
+    (tmp_path / "tsconfig.json").write_text("{}")
+    (tmp_path / "package.json").write_text(
+        '{"name":"x","dependencies":{"react":"^18.0.0","react-dom":"^18.0.0"}}'
+    )
+    info = FrameworkDetector(tmp_path).detect()
+    assert info.typescript is True
+    assert info.framework == FrameworkType.REACT_TYPESCRIPT
+
+
+def test_package_manager_bun(tmp_path: Path) -> None:
+    (tmp_path / "bun.lockb").write_text("")
+    (tmp_path / "package.json").write_text("{}")
+    info = FrameworkDetector(tmp_path).detect()
+    assert info.package_manager == "bun"
+
+
+def test_package_node_from_framework_info() -> None:
+    info = FrameworkInfo(
+        framework=FrameworkType.NEXTJS,
+        version="^14.0.0",
+        typescript=True,
+        styling=["tailwind"],
+        router="next/router",
+        state_management=["zustand"],
+        ui_library="shadcn",
+        build_tool="next",
+        package_manager="bun",
+        confidence=0.92,
+    )
+    p = PackageNode.from_framework_info("packages/web", info)
+    assert p.name == "packages/web"
+    assert p.framework == "Next.js"          # display name, not enum value
+    assert p.framework_version == "^14.0.0"
+    assert p.typescript is True
+    assert p.styling == ["tailwind"]
+    assert p.router == "next/router"
+    assert p.state_management == ["zustand"]
+    assert p.confidence == pytest.approx(0.92)
+    assert p.id == "package:packages/web"
+
+
+def test_unknown_display_name_is_preserved() -> None:
+    info = FrameworkInfo(framework=FrameworkType.UNKNOWN, confidence=0.0)
+    p = PackageNode.from_framework_info("packages/misc", info)
+    assert p.framework == "Unknown"
+    assert p.confidence == 0.0

--- a/codegraph/tests/test_framework.py
+++ b/codegraph/tests/test_framework.py
@@ -1,6 +1,7 @@
 """Tests for :mod:`codegraph.framework`."""
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ from codegraph.framework import FrameworkDetector, FrameworkInfo, FrameworkType
 from codegraph.schema import PackageNode
 
 FIXTURES = Path("/tmp/agent-onboarding/tests/fixtures")
+TWENTY = Path("/tmp/twenty")
 
 
 @pytest.mark.parametrize(
@@ -114,3 +116,144 @@ def test_unknown_display_name_is_preserved() -> None:
     p = PackageNode.from_framework_info("packages/misc", info)
     assert p.framework == "Unknown"
     assert p.confidence == 0.0
+
+
+# ── monorepo walk-up ─────────────────────────────────────────────────
+
+
+def test_walk_up_stops_at_git_root(tmp_path: Path) -> None:
+    root = tmp_path / "monorepo"
+    pkg = root / "packages" / "server"
+    pkg.mkdir(parents=True)
+    (root / ".git").mkdir()
+    paths = list(FrameworkDetector(pkg)._walk_up_to_repo_root())
+    assert paths == [pkg, pkg.parent, root]
+
+
+def test_walk_up_terminates_at_filesystem_root(tmp_path: Path) -> None:
+    pkg = tmp_path / "a" / "b"
+    pkg.mkdir(parents=True)
+    paths = list(FrameworkDetector(pkg)._walk_up_to_repo_root())
+    assert paths[0] == pkg
+    assert len(paths) <= 10
+    # Must not infinite-loop even with no .git marker.
+
+
+def test_package_manager_from_parent_lockfile(tmp_path: Path) -> None:
+    root = tmp_path / "mono"
+    pkg = root / "packages" / "srv"
+    pkg.mkdir(parents=True)
+    (root / ".git").mkdir()
+    (root / "yarn.lock").write_text("")
+    (pkg / "package.json").write_text("{}")
+    info = FrameworkDetector(pkg).detect()
+    assert info.package_manager == "yarn"
+
+
+# ── NestJS ───────────────────────────────────────────────────────────
+
+
+def test_nestjs_wins_over_react_on_same_package(tmp_path: Path) -> None:
+    """A NestJS backend with React in its deps (for SSR email templates)
+    should score NestJS decisively, not React."""
+    root = tmp_path / "mono"
+    pkg = root / "packages" / "server"
+    pkg.mkdir(parents=True)
+    (root / ".git").mkdir()
+    (pkg / "nest-cli.json").write_text("{}")
+    (pkg / "package.json").write_text(json.dumps({
+        "name": "server",
+        "dependencies": {
+            "@nestjs/core": "11.0.0",
+            "@nestjs/common": "11.0.0",
+            "react": "18.3.1",
+            "react-dom": "18.3.1",
+        },
+    }))
+    (pkg / "src").mkdir()
+    (pkg / "src" / "app.module.ts").write_text(
+        "@Module({ imports: [] }) export class AppModule {}"
+    )
+    (pkg / "src" / "app.controller.ts").write_text(
+        "@Controller('users') export class UserController {}"
+    )
+    (pkg / "src" / "user.service.ts").write_text(
+        "@Injectable() export class UserService {}"
+    )
+    info = FrameworkDetector(pkg).detect()
+    assert info.framework == FrameworkType.NESTJS
+    assert info.version == "11.0.0"
+    assert info.confidence >= 0.9
+
+
+def test_nestjs_display_name() -> None:
+    info = FrameworkInfo(framework=FrameworkType.NESTJS, version="11.0.0", confidence=1.0)
+    assert info.display_name == "NestJS"
+    p = PackageNode.from_framework_info("packages/srv", info)
+    assert p.framework == "NestJS"
+
+
+# ── Workspace hoisting ───────────────────────────────────────────────
+
+
+def test_workspace_hoisting_exposes_root_deps(tmp_path: Path) -> None:
+    """twenty-front-shape: child package.json is empty, root has `workspaces`
+    + react deps. The detector must see react through the walk-up."""
+    root = tmp_path / "mono"
+    pkg = root / "packages" / "front"
+    pkg.mkdir(parents=True)
+    (root / ".git").mkdir()
+    (root / "package.json").write_text(json.dumps({
+        "name": "mono",
+        "workspaces": ["packages/*"],
+        "dependencies": {"react": "^18.2.0", "react-dom": "^18.2.0"},
+    }))
+    (pkg / "package.json").write_text('{"name":"front"}')
+    (pkg / "src").mkdir()
+    (pkg / "src" / "App.tsx").write_text(
+        "import React from 'react';\nexport default function App() { return null; }"
+    )
+    info = FrameworkDetector(pkg).detect()
+    assert info.framework in (FrameworkType.REACT, FrameworkType.REACT_TYPESCRIPT)
+    assert info.confidence >= 0.5
+    assert info.version == "^18.2.0"
+
+
+def test_workspaces_guard_blocks_unrelated_parent(tmp_path: Path) -> None:
+    """A parent package.json WITHOUT a `workspaces` field must not leak deps
+    into a child project — otherwise running codegraph from a subdirectory
+    of an unrelated enclosing project would cross-contaminate detection."""
+    root = tmp_path / "unrelated"
+    pkg = root / "subdir" / "project"
+    pkg.mkdir(parents=True)
+    # Deliberately NO .git here — we want to test walk termination without
+    # the git-root short-circuit interfering.
+    (root / "package.json").write_text(json.dumps({
+        "name": "unrelated",
+        "dependencies": {"react": "^18.0.0", "react-dom": "^18.0.0"},
+    }))
+    (pkg / "package.json").write_text('{"name":"project"}')
+    info = FrameworkDetector(pkg).detect()
+    assert info.framework == FrameworkType.UNKNOWN
+
+
+# ── Twenty CRM integration (opt-in) ──────────────────────────────────
+
+
+@pytest.mark.skipif(not TWENTY.exists(), reason="twenty monorepo not at /tmp/twenty")
+def test_twenty_server_is_nestjs() -> None:
+    info = FrameworkDetector(TWENTY / "packages" / "twenty-server").detect()
+    assert info.framework == FrameworkType.NESTJS
+    assert info.version is not None and info.version.startswith("11.")
+    assert info.package_manager == "yarn"
+    assert info.confidence >= 0.9
+
+
+@pytest.mark.skipif(not TWENTY.exists(), reason="twenty monorepo not at /tmp/twenty")
+def test_twenty_front_is_react_with_high_confidence() -> None:
+    info = FrameworkDetector(TWENTY / "packages" / "twenty-front").detect()
+    assert info.framework in (FrameworkType.REACT, FrameworkType.REACT_TYPESCRIPT)
+    assert info.typescript is True
+    assert info.package_manager == "yarn"
+    # Real observed value should be ≥ 0.8 after the fix; 0.5 is conservative.
+    assert info.confidence >= 0.5

--- a/codegraph/tests/test_ignore.py
+++ b/codegraph/tests/test_ignore.py
@@ -1,0 +1,95 @@
+"""Tests for :mod:`codegraph.ignore`."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codegraph.ignore import IgnoreConfigError, IgnoreFilter
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / ".codegraphignore"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(IgnoreConfigError):
+        IgnoreFilter(tmp_path / "does-not-exist")
+
+
+def test_comments_and_blanks_skipped(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "\n# this is a comment\n\n   \n# another\n"))
+    assert f.counts() == (0, 0, 0)
+
+
+def test_file_glob_double_star(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "**/admin/**\n"))
+    assert f.should_ignore_file("src/admin/Users.tsx")
+    assert f.should_ignore_file("packages/server/src/admin/deep/nested/File.ts")
+    assert not f.should_ignore_file("src/users/Admin.tsx")  # "admin" not a dir here
+    assert not f.should_ignore_file("src/public/Home.tsx")
+
+
+def test_file_glob_suffix(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "**/*.secret.ts\n"))
+    assert f.should_ignore_file("src/lib/keys.secret.ts")
+    assert not f.should_ignore_file("src/lib/keys.ts")
+
+
+def test_file_glob_root_anchored(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "/src/admin/\n"))
+    assert f.should_ignore_file("src/admin/Users.tsx")
+    assert not f.should_ignore_file("packages/app/src/admin/Users.tsx")
+
+
+def test_negation_restores_path(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "**/admin/**\n!**/admin/public/**\n"))
+    assert f.should_ignore_file("src/admin/Users.tsx")
+    assert not f.should_ignore_file("src/admin/public/Landing.tsx")
+
+
+def test_route_wildcard(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "@route:/admin/*\n"))
+    assert f.should_ignore_route("/admin/users")
+    assert f.should_ignore_route("admin/users")  # auto-prefixed with /
+    assert not f.should_ignore_route("/users")
+    assert not f.should_ignore_route("/dashboard/admin")
+
+
+def test_route_double_star(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "@route:/admin/**\n"))
+    assert f.should_ignore_route("/admin/users/123/edit")
+    assert f.should_ignore_route("/admin/x")
+
+
+def test_component_substring(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "@component:*Admin*\n"))
+    assert f.should_ignore_component("AdminPanel")
+    assert f.should_ignore_component("UserAdminList")
+    assert not f.should_ignore_component("UserList")
+
+
+def test_component_case_insensitive(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "@component:*internal*\n"))
+    assert f.should_ignore_component("InternalDashboard")
+
+
+def test_mixed_pattern_types_count(tmp_path: Path) -> None:
+    content = (
+        "**/admin/**\n"
+        "**/*.secret.ts\n"
+        "@route:/admin/*\n"
+        "@route:/settings/system/*\n"
+        "@component:*Admin*\n"
+    )
+    f = IgnoreFilter(_write(tmp_path, content))
+    assert f.counts() == (2, 2, 1)
+
+
+def test_no_matches_returns_false(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "**/admin/**\n"))
+    assert not f.should_ignore_file("src/users/Profile.tsx")
+    assert not f.should_ignore_route("/users")
+    assert not f.should_ignore_component("UserList")

--- a/codegraph/tests/test_ignore.py
+++ b/codegraph/tests/test_ignore.py
@@ -1,11 +1,14 @@
-"""Tests for :mod:`codegraph.ignore`."""
+"""Tests for :mod:`codegraph.ignore` and the ``cli.py`` ignore hooks."""
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
 
+from codegraph.cli import _load_ignore_filter, _strip_ignored_components
 from codegraph.ignore import IgnoreConfigError, IgnoreFilter
+from codegraph.resolver import Index
+from codegraph.schema import FileNode, FunctionNode, ParseResult
 
 
 def _write(tmp_path: Path, content: str) -> Path:
@@ -93,3 +96,87 @@ def test_no_matches_returns_false(tmp_path: Path) -> None:
     assert not f.should_ignore_file("src/users/Profile.tsx")
     assert not f.should_ignore_route("/users")
     assert not f.should_ignore_component("UserList")
+
+
+# ── cli.py integration ──────────────────────────────────────────────
+
+
+def _make_index_with_components(*names_and_flags: tuple[str, bool]) -> Index:
+    """Build a minimal :class:`Index` containing one file with the given
+    functions. Each tuple is ``(name, is_component)``."""
+    idx = Index()
+    fnode = FileNode(path="src/ui.tsx", package="web", language="tsx", loc=10)
+    pr = ParseResult(file=fnode)
+    for name, is_component in names_and_flags:
+        pr.functions.append(
+            FunctionNode(name=name, file="src/ui.tsx", is_component=is_component)
+        )
+    idx.files_by_path["src/ui.tsx"] = pr
+    return idx
+
+
+def test_strip_ignored_components_flips_only_matching_ones(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "@component:*Admin*\n"))
+    idx = _make_index_with_components(
+        ("AdminPanel", True),    # should flip
+        ("UserList", True),      # should NOT flip — no match
+        ("AdminHelper", False),  # should NOT flip — already not a component
+    )
+
+    dropped = _strip_ignored_components(idx, f)
+
+    assert dropped == 1
+    fns = {fn.name: fn.is_component for fn in idx.files_by_path["src/ui.tsx"].functions}
+    assert fns == {
+        "AdminPanel": False,    # flipped
+        "UserList": True,       # untouched
+        "AdminHelper": False,   # was already False
+    }
+
+
+def test_strip_ignored_components_zero_matches(tmp_path: Path) -> None:
+    f = IgnoreFilter(_write(tmp_path, "@component:*Secret*\n"))
+    idx = _make_index_with_components(("UserList", True), ("AdminPanel", True))
+    dropped = _strip_ignored_components(idx, f)
+    assert dropped == 0
+    # Both components remain flagged.
+    fns = {fn.name: fn.is_component for fn in idx.files_by_path["src/ui.tsx"].functions}
+    assert fns == {"UserList": True, "AdminPanel": True}
+
+
+def test_load_ignore_filter_auto_detects_default(tmp_path: Path) -> None:
+    (tmp_path / ".codegraphignore").write_text("**/admin/**\n")
+    filt = _load_ignore_filter(tmp_path, configured=None)
+    assert filt is not None
+    assert filt.should_ignore_file("src/admin/Users.tsx")
+
+
+def test_load_ignore_filter_returns_none_when_no_default(tmp_path: Path) -> None:
+    assert _load_ignore_filter(tmp_path, configured=None) is None
+
+
+def test_load_ignore_filter_explicit_missing_relative_path_raises(tmp_path: Path) -> None:
+    """Relative path resolved against ``repo`` and missing → hard error.
+
+    Paired with the absolute-path case below so both resolution branches of
+    :func:`_load_ignore_filter` are covered."""
+    with pytest.raises(IgnoreConfigError):
+        _load_ignore_filter(tmp_path, configured="does-not-exist.ignore")
+
+
+def test_load_ignore_filter_explicit_missing_absolute_path_raises(tmp_path: Path) -> None:
+    """Absolute path bypasses the ``repo / candidate`` join; missing → hard error."""
+    missing = tmp_path / "nowhere" / "absent.ignore"
+    assert missing.is_absolute()
+    assert not missing.exists()
+    with pytest.raises(IgnoreConfigError):
+        _load_ignore_filter(tmp_path, configured=str(missing))
+
+
+def test_load_ignore_filter_explicit_absolute_path(tmp_path: Path) -> None:
+    target = tmp_path / "custom" / "my.ignore"
+    target.parent.mkdir()
+    target.write_text("@component:*Admin*\n")
+    filt = _load_ignore_filter(tmp_path, configured=str(target))
+    assert filt is not None
+    assert filt.should_ignore_component("AdminPanel")

--- a/codegraph/tests/test_loader_pairing.py
+++ b/codegraph/tests/test_loader_pairing.py
@@ -1,0 +1,110 @@
+"""Tests for :func:`codegraph.loader._write_test_edges`.
+
+Builds a synthetic :class:`~codegraph.resolver.Index` with a handful of
+``ParseResult`` entries and verifies the test-to-production pairing rules
+(TS + Python, same-directory only for Python MVP). Monkeypatches
+``loader._run`` so no Neo4j is needed.
+"""
+from __future__ import annotations
+
+import pytest
+
+from codegraph import loader
+from codegraph.resolver import Index
+from codegraph.schema import FileNode, ParseResult
+
+
+def _fake_index(files: dict[str, bool]) -> Index:
+    """Build an Index with files keyed by path; value = is_test flag."""
+    idx = Index()
+    for path, is_test in files.items():
+        language = "py" if path.endswith(".py") else "ts"
+        fn = FileNode(path=path, package="p", language=language, loc=1, is_test=is_test)
+        idx.files_by_path[path] = ParseResult(file=fn)
+    return idx
+
+
+class _Stats:
+    def __init__(self):
+        self.edges: dict = {}
+
+
+@pytest.fixture
+def captured_runs(monkeypatch):
+    calls: list[tuple[str, list]] = []
+
+    def fake_run(session, cypher, rows):
+        calls.append((cypher, list(rows)))
+
+    monkeypatch.setattr(loader, "_run", fake_run)
+    return calls
+
+
+def _tests_rows(captured_runs):
+    """Extract the rows passed to the TESTS (file→file) MERGE."""
+    for cypher, rows in captured_runs:
+        if "MERGE (t)-[:TESTS]->(p)" in cypher:
+            return rows
+    return []
+
+
+def test_python_test_prefix_pairs(captured_runs):
+    """``pkg/test_foo.py`` pairs to ``pkg/foo.py`` (same directory)."""
+    idx = _fake_index({
+        "pkg/test_foo.py": True,
+        "pkg/foo.py": False,
+    })
+    loader._write_test_edges(session=None, index=idx, stats=_Stats())
+    rows = _tests_rows(captured_runs)
+    assert rows == [{"test": "pkg/test_foo.py", "peer": "pkg/foo.py"}]
+
+
+def test_python_test_trailing_pairs(captured_runs):
+    """``pkg/foo_test.py`` pairs to ``pkg/foo.py``."""
+    idx = _fake_index({
+        "pkg/foo_test.py": True,
+        "pkg/foo.py": False,
+    })
+    loader._write_test_edges(session=None, index=idx, stats=_Stats())
+    rows = _tests_rows(captured_runs)
+    assert rows == [{"test": "pkg/foo_test.py", "peer": "pkg/foo.py"}]
+
+
+def test_conftest_does_not_pair(captured_runs):
+    """``conftest.py`` is a pytest fixture collector — no production peer."""
+    idx = _fake_index({
+        "pkg/conftest.py": True,
+        "pkg/context.py": False,    # ``conf``-prefixed near-match, must not pair
+    })
+    loader._write_test_edges(session=None, index=idx, stats=_Stats())
+    assert _tests_rows(captured_runs) == []
+
+
+def test_test_without_peer_does_not_pair(captured_runs):
+    """``test_orphan.py`` with no sibling ``orphan.py`` → no edge."""
+    idx = _fake_index({
+        "pkg/test_orphan.py": True,
+    })
+    loader._write_test_edges(session=None, index=idx, stats=_Stats())
+    assert _tests_rows(captured_runs) == []
+
+
+def test_cross_directory_python_does_not_pair(captured_runs):
+    """Same-directory rule: ``tests/test_foo.py`` does NOT pair to ``pkg/foo.py``."""
+    idx = _fake_index({
+        "tests/test_foo.py": True,
+        "pkg/foo.py": False,
+    })
+    loader._write_test_edges(session=None, index=idx, stats=_Stats())
+    assert _tests_rows(captured_runs) == []
+
+
+def test_ts_pairing_still_works(captured_runs):
+    """TS pairing must not regress: ``foo.spec.ts`` → ``foo.ts``."""
+    idx = _fake_index({
+        "pkg/foo.spec.ts": True,
+        "pkg/foo.ts": False,
+    })
+    loader._write_test_edges(session=None, index=idx, stats=_Stats())
+    rows = _tests_rows(captured_runs)
+    assert rows == [{"test": "pkg/foo.spec.ts", "peer": "pkg/foo.ts"}]

--- a/codegraph/tests/test_loader_partitioning.py
+++ b/codegraph/tests/test_loader_partitioning.py
@@ -1,0 +1,100 @@
+"""Tests for :mod:`codegraph.loader`'s edge partitioner.
+
+These don't touch Neo4j — they monkeypatch ``loader._run`` to capture the
+``(cypher, rows)`` tuples the partitioner produces. That lets us assert the
+routing logic directly without a live session.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codegraph import loader
+from codegraph.py_parser import PyParser
+from codegraph.schema import DECORATED_BY, Edge
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CODEGRAPH_PKG = REPO_ROOT / "codegraph" / "codegraph"
+
+
+class _Stats:
+    """Minimal LoadStats stand-in for partitioner tests."""
+
+    def __init__(self):
+        self.edges: dict = {}
+
+
+@pytest.fixture
+def captured_runs(monkeypatch):
+    """Monkeypatch ``loader._run`` to record every (cypher, rows) pair."""
+    calls: list[tuple[str, list]] = []
+
+    def fake_run(session, cypher, rows):
+        calls.append((cypher, list(rows)))
+
+    monkeypatch.setattr(loader, "_run", fake_run)
+    return calls
+
+
+def test_decorated_by_partitions_function_src_ids(captured_runs):
+    """func:-prefixed DECORATED_BY edges must reach a Function MERGE."""
+    edges = [
+        Edge(kind=DECORATED_BY, src_id="class:a.py#A", dst_id="dec:dataclass"),
+        Edge(kind=DECORATED_BY, src_id="func:b.py#helper", dst_id="dec:staticmethod"),
+        Edge(kind=DECORATED_BY, src_id="func:c.py#main", dst_id="dec:app.command()"),
+        Edge(kind=DECORATED_BY, src_id="method:class:d.py#D#run", dst_id="dec:property"),
+    ]
+    stats = _Stats()
+
+    loader._write_edges(session=None, edges=edges, stats=stats)
+
+    # Find the Function MERGE call and check the rows it got.
+    func_runs = [
+        (cypher, rows) for cypher, rows in captured_runs
+        if "MATCH (a:Function {id: r.src})" in cypher
+        and "MERGE (a)-[:DECORATED_BY]->(d)" in cypher
+    ]
+    assert len(func_runs) == 1, "expected exactly one Function DECORATED_BY MERGE"
+    rows = func_runs[0][1]
+    assert len(rows) == 2
+    src_ids = {r["src"] for r in rows}
+    assert src_ids == {"func:b.py#helper", "func:c.py#main"}
+
+    # Stats total covers all three buckets (class=1, func=2, method=1).
+    assert stats.edges[DECORATED_BY] == 4
+
+
+def test_decorated_by_func_smoke_from_parser():
+    """Parsing ``mcp.py`` must yield exactly 13 function-level decorators.
+
+    All are ``@mcp.tool()`` on module-level tool functions. If this count
+    changes, ``mcp.py`` grew a new tool — update this assertion and ROADMAP.
+    """
+    parser = PyParser()
+    rel = "codegraph/codegraph/mcp.py"
+    result = parser.parse_file(CODEGRAPH_PKG / "mcp.py", rel, "codegraph")
+    assert result is not None
+    func_decs = [
+        e for e in result.edges
+        if e.kind == DECORATED_BY and e.src_id.startswith("func:")
+    ]
+    assert len(func_decs) == 13
+    assert all(e.dst_id == "dec:mcp.tool()" for e in func_decs)
+
+
+def test_unknown_prefix_logs_debug(captured_runs, caplog):
+    """Unknown src_id prefixes drop through with a debug-log breadcrumb."""
+    import logging
+    caplog.set_level(logging.DEBUG, logger="codegraph.loader")
+
+    edges = [
+        Edge(kind=DECORATED_BY, src_id="garbage:x#y", dst_id="dec:whatever"),
+    ]
+    loader._write_edges(session=None, edges=edges, stats=_Stats())
+
+    assert any(
+        "unknown src prefix" in rec.message and "garbage:x#y" in rec.message
+        for rec in caplog.records
+    ), "expected a debug log about the unknown prefix"

--- a/codegraph/tests/test_mcp.py
+++ b/codegraph/tests/test_mcp.py
@@ -259,3 +259,234 @@ def test_read_session_is_read_only(monkeypatch):
         pass
     from neo4j import READ_ACCESS
     assert captured.get("default_access_mode") == READ_ACCESS
+
+
+# ── _validate_limit ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [0, -1, 1001, "10", None, 3.5, True, False],
+)
+def test_validate_limit_rejects(bad):
+    assert mcp_mod._validate_limit(bad) is not None
+
+
+@pytest.mark.parametrize("good", [1, 50, 1000])
+def test_validate_limit_accepts(good):
+    assert mcp_mod._validate_limit(good) is None
+
+
+def test_validate_limit_custom_max():
+    assert mcp_mod._validate_limit(50, max_limit=100) is None
+    assert mcp_mod._validate_limit(101, max_limit=100) is not None
+
+
+# ── files_in_package ────────────────────────────────────────────────
+
+
+def test_files_in_package_happy_path(monkeypatch):
+    driver = _patch(
+        monkeypatch,
+        [[
+            {
+                "path": "packages/srv/src/a.ts",
+                "language": "ts",
+                "loc": 120,
+                "is_controller": False,
+                "is_component": False,
+                "is_injectable": True,
+                "is_module": False,
+                "is_entity": False,
+            }
+        ]],
+    )
+    out = mcp_mod.files_in_package("srv")
+    assert len(out) == 1
+    assert out[0]["path"] == "packages/srv/src/a.ts"
+    cypher, params = driver.session_obj.calls[0]
+    assert "(f:File {package: $name})" in cypher
+    assert "LIMIT 50" in cypher
+    assert params == {"name": "srv"}
+
+
+def test_files_in_package_interpolates_custom_limit(monkeypatch):
+    driver = _patch(monkeypatch, [[]])
+    mcp_mod.files_in_package("srv", limit=250)
+    cypher, _ = driver.session_obj.calls[0]
+    assert "LIMIT 250" in cypher
+
+
+def test_files_in_package_rejects_bad_limit(monkeypatch):
+    _patch(monkeypatch, [[]])
+    out = mcp_mod.files_in_package("srv", limit=0)
+    assert out == [{"error": "limit must be an integer in 1..1000"}]
+
+
+# ── hook_usage ──────────────────────────────────────────────────────
+
+
+def test_hook_usage_happy_path(monkeypatch):
+    driver = _patch(
+        monkeypatch,
+        [[
+            {"name": "LoginForm", "file": "src/ui/LoginForm.tsx", "is_component": True},
+            {"name": "useAuthGate", "file": "src/hooks/useAuthGate.ts", "is_component": False},
+        ]],
+    )
+    out = mcp_mod.hook_usage("useAuth")
+    assert [row["name"] for row in out] == ["LoginForm", "useAuthGate"]
+    cypher, params = driver.session_obj.calls[0]
+    assert "(fn:Function)-[:USES_HOOK]->(:Hook {name: $hook_name})" in cypher
+    assert "DISTINCT" in cypher
+    assert params == {"hook_name": "useAuth"}
+
+
+def test_hook_usage_empty_result(monkeypatch):
+    _patch(monkeypatch, [[]])
+    assert mcp_mod.hook_usage("useNonexistent") == []
+
+
+def test_hook_usage_rejects_bad_limit(monkeypatch):
+    _patch(monkeypatch, [[]])
+    out = mcp_mod.hook_usage("useAuth", limit=-5)
+    assert out == [{"error": "limit must be an integer in 1..1000"}]
+
+
+# ── gql_operation_callers ───────────────────────────────────────────
+
+
+def test_gql_operation_callers_no_type_filter(monkeypatch):
+    driver = _patch(
+        monkeypatch,
+        [[
+            {
+                "caller_name": "UserListPage",
+                "caller_file": "src/pages/UserList.tsx",
+                "caller_kind": "Function",
+                "op_type": "query",
+                "return_type": "UserConnection",
+            }
+        ]],
+    )
+    out = mcp_mod.gql_operation_callers("findManyUsers")
+    assert out[0]["caller_kind"] == "Function"
+    cypher, params = driver.session_obj.calls[0]
+    assert "labels(caller)[0] AS caller_kind" in cypher
+    assert params == {"op_name": "findManyUsers", "op_type": None}
+
+
+def test_gql_operation_callers_with_type(monkeypatch):
+    driver = _patch(monkeypatch, [[]])
+    mcp_mod.gql_operation_callers("createUser", op_type="mutation")
+    _, params = driver.session_obj.calls[0]
+    assert params == {"op_name": "createUser", "op_type": "mutation"}
+
+
+@pytest.mark.parametrize("bad_type", ["fetch", "qurey", "QUERY", "", "subscription ", "all"])
+def test_gql_operation_callers_rejects_bad_op_type(monkeypatch, bad_type):
+    _patch(monkeypatch, [[]])
+    out = mcp_mod.gql_operation_callers("findManyUsers", op_type=bad_type)
+    assert out == [{"error": "op_type must be one of 'query' | 'mutation' | 'subscription'"}]
+
+
+# ── most_injected_services ──────────────────────────────────────────
+
+
+def test_most_injected_services_happy_path(monkeypatch):
+    driver = _patch(
+        monkeypatch,
+        [[
+            {"name": "ConfigService", "file": "src/config/config.service.ts",
+             "injections": 136, "is_controller": False},
+            {"name": "AuthService", "file": "src/auth/auth.service.ts",
+             "injections": 87, "is_controller": False},
+        ]],
+    )
+    out = mcp_mod.most_injected_services(limit=5)
+    assert out[0]["injections"] == 136
+    cypher, _ = driver.session_obj.calls[0]
+    assert "(svc:Class {is_injectable: true})<-[:INJECTS]-(caller:Class)" in cypher
+    assert "count(DISTINCT caller)" in cypher
+    assert "LIMIT 5" in cypher
+    assert "ORDER BY injections DESC" in cypher
+
+
+def test_most_injected_services_tight_limit_cap(monkeypatch):
+    _patch(monkeypatch, [[]])
+    out = mcp_mod.most_injected_services(limit=500)
+    assert out == [{"error": "limit must be an integer in 1..100"}]
+
+
+# ── find_class ──────────────────────────────────────────────────────
+
+
+def test_find_class_happy_path(monkeypatch):
+    driver = _patch(
+        monkeypatch,
+        [[
+            {"name": "AuthService", "file": "src/auth/auth.service.ts",
+             "is_controller": False, "is_injectable": True, "is_module": False,
+             "is_entity": False, "is_resolver": False},
+            {"name": "AuthGuard", "file": "src/auth/auth.guard.ts",
+             "is_controller": False, "is_injectable": True, "is_module": False,
+             "is_entity": False, "is_resolver": False},
+        ]],
+    )
+    out = mcp_mod.find_class("Auth")
+    assert [r["name"] for r in out] == ["AuthService", "AuthGuard"]
+    cypher, params = driver.session_obj.calls[0]
+    assert "c.name CONTAINS $name_pattern" in cypher
+    assert params == {"name_pattern": "Auth"}
+
+
+def test_find_class_rejects_empty_pattern(monkeypatch):
+    _patch(monkeypatch, [[]])
+    out = mcp_mod.find_class("")
+    assert out == [{"error": "name_pattern must be non-empty"}]
+
+
+def test_find_class_rejects_bad_limit(monkeypatch):
+    _patch(monkeypatch, [[]])
+    out = mcp_mod.find_class("Auth", limit=99999)
+    assert out == [{"error": "limit must be an integer in 1..1000"}]
+
+
+# ── Parametrized error paths across all new tools ───────────────────
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: mcp_mod.files_in_package("srv"),
+        lambda: mcp_mod.hook_usage("useAuth"),
+        lambda: mcp_mod.gql_operation_callers("findManyUsers"),
+        lambda: mcp_mod.most_injected_services(),
+        lambda: mcp_mod.find_class("Auth"),
+    ],
+)
+def test_new_tools_surface_client_error(monkeypatch, call):
+    _patch(monkeypatch, ClientError("nope"))
+    out = call()
+    assert len(out) == 1 and "error" in out[0]
+    assert "Neo4j rejected query" in out[0]["error"]
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: mcp_mod.files_in_package("srv"),
+        lambda: mcp_mod.hook_usage("useAuth"),
+        lambda: mcp_mod.gql_operation_callers("findManyUsers"),
+        lambda: mcp_mod.most_injected_services(),
+        lambda: mcp_mod.find_class("Auth"),
+    ],
+)
+def test_new_tools_surface_service_unavailable(monkeypatch, call):
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        _patch(monkeypatch, ServiceUnavailable("down"))
+        out = call()
+    assert len(out) == 1 and "error" in out[0]
+    assert "Neo4j is unreachable" in out[0]["error"]

--- a/codegraph/tests/test_mcp.py
+++ b/codegraph/tests/test_mcp.py
@@ -1,0 +1,231 @@
+"""Tests for :mod:`codegraph.mcp`.
+
+Every test monkeypatches ``codegraph.mcp._driver`` with a fake implementation,
+so no Neo4j instance is required. FastMCP 1.x leaves ``@mcp.tool()``-decorated
+functions as plain callables — the tests invoke them directly.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from neo4j.exceptions import ClientError, CypherSyntaxError, ServiceUnavailable
+
+import codegraph.mcp as mcp_mod
+
+
+# ── Fakes ───────────────────────────────────────────────────────────
+
+
+class _FakeRecord:
+    """Stand-in for a neo4j ``Record``. Supports ``items()`` + subscript."""
+
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def items(self):
+        return self._data.items()
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+
+class _FakeSession:
+    def __init__(self, responses: list[list[dict]] | Exception) -> None:
+        self._responses = responses
+        self.calls: list[tuple[str, dict]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        pass
+
+    def run(self, cypher: str, **params: Any):
+        self.calls.append((cypher, params))
+        if isinstance(self._responses, Exception):
+            raise self._responses
+        if not self._responses:
+            return iter([])
+        rows = self._responses.pop(0) if len(self._responses) > 1 else self._responses[0]
+        return iter([_FakeRecord(r) for r in rows])
+
+
+class _FakeDriver:
+    def __init__(self, responses: list[list[dict]] | Exception) -> None:
+        self.session_obj = _FakeSession(responses)
+        self.closed = False
+
+    def session(self, **kwargs: Any):
+        return self.session_obj
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _patch(monkeypatch, responses):
+    driver = _FakeDriver(responses)
+    monkeypatch.setattr(mcp_mod, "_driver", driver)
+    return driver
+
+
+# ── query_graph ─────────────────────────────────────────────────────
+
+
+def test_query_graph_returns_flat_dicts(monkeypatch):
+    driver = _patch(monkeypatch, [[{"f.path": "src/a.ts", "n": 3}]])
+    out = mcp_mod.query_graph("MATCH (f:File) RETURN f.path, count(*) AS n")
+    assert out == [{"f.path": "src/a.ts", "n": 3}]
+    cypher, _ = driver.session_obj.calls[0]
+    assert "MATCH (f:File)" in cypher
+
+
+def test_query_graph_respects_limit(monkeypatch):
+    _patch(monkeypatch, [[{"n": i} for i in range(50)]])
+    out = mcp_mod.query_graph("MATCH (n) RETURN n", limit=5)
+    assert len(out) == 5
+
+
+def test_query_graph_rejects_bad_limit(monkeypatch):
+    _patch(monkeypatch, [[{"n": 1}]])
+    result = mcp_mod.query_graph("MATCH (n) RETURN n", limit=0)
+    assert result == [{"error": "limit must be a positive integer"}]
+
+
+def test_query_graph_caps_huge_limit(monkeypatch):
+    _patch(monkeypatch, [[{"n": i} for i in range(2000)]])
+    out = mcp_mod.query_graph("MATCH (n) RETURN n", limit=5000)
+    assert len(out) == 1000  # capped
+
+
+def test_query_graph_surfaces_client_error(monkeypatch):
+    _patch(monkeypatch, ClientError("Write queries are not allowed on this session"))
+    out = mcp_mod.query_graph("CREATE (x:Foo)")
+    assert out[0]["error"].startswith("Neo4j rejected query:")
+    assert "Write queries" in out[0]["error"]
+
+
+def test_query_graph_surfaces_syntax_error(monkeypatch):
+    _patch(monkeypatch, CypherSyntaxError("Invalid input 'QQ'"))
+    out = mcp_mod.query_graph("QQ")
+    assert out[0]["error"].startswith("Cypher syntax error:")
+
+
+def test_query_graph_surfaces_service_unavailable(monkeypatch):
+    _patch(monkeypatch, ServiceUnavailable("connection refused"))
+    out = mcp_mod.query_graph("MATCH (n) RETURN n")
+    assert "Neo4j is unreachable" in out[0]["error"]
+
+
+# ── describe_schema ─────────────────────────────────────────────────
+
+
+def test_describe_schema_stitches_three_queries(monkeypatch):
+    driver = _patch(
+        monkeypatch,
+        [
+            [{"label": "Class"}, {"label": "File"}],
+            [{"relationshipType": "IMPORTS"}, {"relationshipType": "INJECTS"}],
+            [{"label": "Class", "n": 50}, {"label": "File", "n": 200}],
+        ],
+    )
+    out = mcp_mod.describe_schema()
+    assert out == {
+        "labels": ["Class", "File"],
+        "rel_types": ["IMPORTS", "INJECTS"],
+        "counts": {"Class": 50, "File": 200},
+    }
+    assert len(driver.session_obj.calls) == 3
+
+
+# ── list_packages ───────────────────────────────────────────────────
+
+
+def test_list_packages_returns_framework_rows(monkeypatch):
+    driver = _patch(
+        monkeypatch,
+        [[
+            {
+                "name": "packages/server",
+                "framework": "Next.js",
+                "framework_version": "^14.0.0",
+                "typescript": True,
+                "package_manager": "bun",
+                "confidence": 0.95,
+            }
+        ]],
+    )
+    out = mcp_mod.list_packages()
+    assert len(out) == 1
+    assert out[0]["framework"] == "Next.js"
+    cypher, _ = driver.session_obj.calls[0]
+    assert "MATCH (p:Package)" in cypher
+
+
+# ── callers_of_class ────────────────────────────────────────────────
+
+
+def test_callers_of_class_default_depth(monkeypatch):
+    driver = _patch(monkeypatch, [[]])
+    mcp_mod.callers_of_class("AuthService")
+    cypher, params = driver.session_obj.calls[0]
+    assert "*1..3" in cypher
+    assert params == {"class_name": "AuthService"}
+
+
+def test_callers_of_class_custom_depth(monkeypatch):
+    driver = _patch(monkeypatch, [[]])
+    mcp_mod.callers_of_class("AuthService", max_depth=7)
+    cypher, _ = driver.session_obj.calls[0]
+    assert "*1..7" in cypher
+
+
+@pytest.mark.parametrize("bad", [0, -1, 11, 100, "3"])
+def test_callers_of_class_rejects_bad_depth(monkeypatch, bad):
+    _patch(monkeypatch, [[]])
+    out = mcp_mod.callers_of_class("AuthService", max_depth=bad)
+    assert out == [{"error": "max_depth must be an integer in 1..10"}]
+
+
+# ── endpoints_for_controller ────────────────────────────────────────
+
+
+def test_endpoints_for_controller_binds_name(monkeypatch):
+    driver = _patch(
+        monkeypatch,
+        [[{"method": "GET", "path": "/users/:id", "handler": "findOne"}]],
+    )
+    out = mcp_mod.endpoints_for_controller("UserController")
+    assert out[0]["path"] == "/users/:id"
+    cypher, params = driver.session_obj.calls[0]
+    assert "is_controller: true" in cypher
+    assert params == {"controller_name": "UserController"}
+
+
+# ── read-only session contract ──────────────────────────────────────
+
+
+def test_read_session_is_read_only(monkeypatch):
+    """Sanity check: `_read_session` asks the driver for a READ_ACCESS session.
+
+    If this ever regresses, write-Cypher from an agent would actually mutate
+    the graph. Worth pinning.
+    """
+    captured: dict = {}
+
+    class _Spy:
+        def session(self, **kw):
+            captured.update(kw)
+            return _FakeSession([])
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(mcp_mod, "_driver", _Spy())
+    with mcp_mod._read_session():
+        pass
+    from neo4j import READ_ACCESS
+    assert captured.get("default_access_mode") == READ_ACCESS

--- a/codegraph/tests/test_mcp.py
+++ b/codegraph/tests/test_mcp.py
@@ -34,6 +34,14 @@ class _FakeRecord:
 
 
 class _FakeSession:
+    """Fake Neo4j session. Responses are a FIFO queue of per-call row lists.
+
+    Each call to :meth:`run` pops the next response off the queue. Calls past
+    the end of the queue return an empty iterator — this makes test
+    multi-call bugs surface as "no rows" rather than silently reusing the
+    last response (which hides queue-exhaustion bugs).
+    """
+
     def __init__(self, responses: list[list[dict]] | Exception) -> None:
         self._responses = responses
         self.calls: list[tuple[str, dict]] = []
@@ -50,7 +58,7 @@ class _FakeSession:
             raise self._responses
         if not self._responses:
             return iter([])
-        rows = self._responses.pop(0) if len(self._responses) > 1 else self._responses[0]
+        rows = self._responses.pop(0)
         return iter([_FakeRecord(r) for r in rows])
 
 
@@ -139,6 +147,28 @@ def test_describe_schema_stitches_three_queries(monkeypatch):
         "counts": {"Class": 50, "File": 200},
     }
     assert len(driver.session_obj.calls) == 3
+
+
+def test_describe_schema_surfaces_client_error(monkeypatch):
+    """Regression: describe_schema previously used `e.message` directly,
+    which is None on ad-hoc Neo4jError instances. The handler now routes
+    through `_err_msg` like every other tool; verify the fallback works.
+    """
+    _patch(monkeypatch, ClientError("db is read-only for some reason"))
+    out = mcp_mod.describe_schema()
+    assert "error" in out
+    assert "Neo4j rejected query" in out["error"]
+    assert "read-only" in out["error"]
+
+
+def test_describe_schema_surfaces_service_unavailable(monkeypatch):
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        _patch(monkeypatch, ServiceUnavailable("cannot connect"))
+        out = mcp_mod.describe_schema()
+    assert "error" in out
+    assert "Neo4j is unreachable" in out["error"]
 
 
 # ── list_packages ───────────────────────────────────────────────────

--- a/codegraph/tests/test_py_parser.py
+++ b/codegraph/tests/test_py_parser.py
@@ -92,13 +92,13 @@ def test_schema_py_defines_class_edges():
 
 
 def test_mcp_py_tool_decorators():
-    """mcp.py ships 11 `@mcp.tool()` tools (10 legacy + describe_function)."""
+    """mcp.py ships 13 `@mcp.tool()` tools (10 legacy + describe_function + calls_from + callers_of)."""
     result = _parse(CODEGRAPH_PKG / "mcp.py")
     tool_edges = [
         e for e in result.edges
         if e.kind == DECORATED_BY and "mcp.tool" in e.dst_id
     ]
-    assert len(tool_edges) == 11
+    assert len(tool_edges) == 13
 
 
 def test_mcp_py_module_functions():

--- a/codegraph/tests/test_py_parser.py
+++ b/codegraph/tests/test_py_parser.py
@@ -91,14 +91,14 @@ def test_schema_py_defines_class_edges():
 # ── mcp.py ground-truth ─────────────────────────────────────────────
 
 
-def test_mcp_py_ten_tool_decorators():
-    """mcp.py ships 10 `@mcp.tool()` tools — that count is load-bearing."""
+def test_mcp_py_tool_decorators():
+    """mcp.py ships 11 `@mcp.tool()` tools (10 legacy + describe_function)."""
     result = _parse(CODEGRAPH_PKG / "mcp.py")
     tool_edges = [
         e for e in result.edges
         if e.kind == DECORATED_BY and "mcp.tool" in e.dst_id
     ]
-    assert len(tool_edges) == 10
+    assert len(tool_edges) == 11
 
 
 def test_mcp_py_module_functions():
@@ -276,3 +276,92 @@ def test_empty_file(tmp_path: Path):
 def test_missing_file_returns_none(tmp_path: Path):
     result = PyParser().parse_file(tmp_path / "nope.py", "nope.py", "pkg")
     assert result is None
+
+
+# ── Docstring + signature extraction ────────────────────────────────
+
+
+def test_function_docstring_dedented(tmp_path: Path):
+    """Triple-quoted docstring is captured, quotes stripped, indentation dedented."""
+    src = (
+        'def greet(name: str) -> str:\n'
+        '    """Say hello.\n'
+        '\n'
+        '    A simple greeter.\n'
+        '    """\n'
+        '    return "hi " + name\n'
+    )
+    f = tmp_path / "a.py"
+    f.write_text(src)
+    result = PyParser().parse_file(f, "a.py", "pkg")
+    assert result is not None
+    fn = result.functions[0]
+    assert fn.docstring.startswith("Say hello.")
+    assert "A simple greeter." in fn.docstring
+    # No surrounding quotes.
+    assert not fn.docstring.startswith('"')
+    assert not fn.docstring.endswith('"')
+
+
+def test_signature_params_and_return_type(tmp_path: Path):
+    """Typed params, defaults, and return type are all extracted."""
+    import json as _json
+    src = 'def f(x: int, y: str = "a", *args, **kwargs) -> bool:\n    return True\n'
+    f = tmp_path / "a.py"
+    f.write_text(src)
+    result = PyParser().parse_file(f, "a.py", "pkg")
+    assert result is not None
+    fn = result.functions[0]
+    assert fn.return_type == "bool"
+    params = _json.loads(fn.params_json)
+    assert len(params) == 4
+    assert params[0] == {"name": "x", "type": "int", "kind": "positional"}
+    assert params[1]["name"] == "y"
+    assert params[1]["type"] == "str"
+    assert params[1]["default"] == '"a"'
+    assert params[2] == {"name": "*args", "kind": "var_positional"}
+    assert params[3] == {"name": "**kwargs", "kind": "var_keyword"}
+
+
+def test_no_docstring_empty_string(tmp_path: Path):
+    """A function without a docstring gets ``""`` (not ``None``)."""
+    f = tmp_path / "a.py"
+    f.write_text("def f():\n    return 1\n")
+    result = PyParser().parse_file(f, "a.py", "pkg")
+    assert result is not None
+    fn = result.functions[0]
+    assert fn.docstring == ""
+    assert fn.return_type == ""
+    assert fn.params_json == "[]"
+
+
+def test_method_docstring_and_self_kept(tmp_path: Path):
+    """Methods get docstrings; ``self`` is kept in params_json for honesty."""
+    import json as _json
+    src = (
+        "class Greeter:\n"
+        "    def greet(self, name: str) -> str:\n"
+        '        """Greet someone."""\n'
+        '        return "hi " + name\n'
+    )
+    f = tmp_path / "a.py"
+    f.write_text(src)
+    result = PyParser().parse_file(f, "a.py", "pkg")
+    assert result is not None
+    assert len(result.methods) == 1
+    m = result.methods[0]
+    assert m.docstring == "Greet someone."
+    params = _json.loads(m.params_json)
+    assert params[0]["name"] == "self"
+    assert len(params) == 2
+    assert m.return_type == "str"
+
+
+def test_docstring_with_non_string_first_stmt(tmp_path: Path):
+    """A non-string first statement means no docstring (PEP 257)."""
+    src = "def f():\n    x = 1\n    return x\n"
+    f = tmp_path / "a.py"
+    f.write_text(src)
+    result = PyParser().parse_file(f, "a.py", "pkg")
+    assert result is not None
+    assert result.functions[0].docstring == ""

--- a/codegraph/tests/test_py_parser.py
+++ b/codegraph/tests/test_py_parser.py
@@ -1,0 +1,278 @@
+"""Tests for :mod:`codegraph.py_parser`.
+
+The target codebase is its own test fixture — we parse real codegraph source
+files and assert against ground-truth counts gathered via stdlib ``ast`` at
+plan time. That gives us high-confidence regression detection: if the parser
+stops finding the 17 dataclasses in ``schema.py`` or the 10 ``@mcp.tool()``
+decorators in ``mcp.py``, something broke.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codegraph.py_parser import PyParser
+from codegraph.schema import DECORATED_BY, DEFINES_CLASS, DEFINES_FUNC, HAS_METHOD
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CODEGRAPH_PKG = REPO_ROOT / "codegraph" / "codegraph"
+
+
+def _parse(abs_path: Path):
+    rel = str(abs_path.resolve().relative_to(REPO_ROOT)).replace("\\", "/")
+    return PyParser().parse_file(abs_path, rel, "codegraph")
+
+
+# ── Sanity / package-wide smoke ─────────────────────────────────────
+
+
+def test_parses_entire_codegraph_package():
+    parser = PyParser()
+    parsed = 0
+    errors = []
+    for p in CODEGRAPH_PKG.rglob("*.py"):
+        if "__pycache__" in p.parts:
+            continue
+        rel = str(p.resolve().relative_to(REPO_ROOT)).replace("\\", "/")
+        try:
+            result = parser.parse_file(p, rel, "codegraph", is_test=False)
+            assert result is not None
+            parsed += 1
+        except Exception as e:
+            errors.append((rel, e))
+    assert not errors, f"parse errors: {errors}"
+    assert parsed >= 15  # 18 Python files in the package
+
+
+# ── schema.py ground-truth assertions ───────────────────────────────
+
+
+def test_schema_py_class_count():
+    result = _parse(CODEGRAPH_PKG / "schema.py")
+    assert len(result.classes) == 17
+    names = {c.name for c in result.classes}
+    assert "PackageNode" in names
+    assert "FileNode" in names
+    assert "ClassNode" in names
+    assert "Edge" in names
+    assert "ImportSpec" in names
+    assert "ParseResult" in names
+
+
+def test_schema_py_dataclass_decorators():
+    """schema.py has exactly 17 `@dataclass` decorators — one per class."""
+    result = _parse(CODEGRAPH_PKG / "schema.py")
+    dataclass_edges = [
+        e for e in result.edges
+        if e.kind == DECORATED_BY and e.dst_id == "dec:dataclass"
+    ]
+    assert len(dataclass_edges) == 17
+
+
+def test_schema_py_imports():
+    result = _parse(CODEGRAPH_PKG / "schema.py")
+    specs = {imp.specifier for imp in result.imports}
+    assert "__future__" in specs
+    assert "dataclasses" in specs
+    assert "typing" in specs
+    # Conditional import under `if TYPE_CHECKING:`
+    assert ".framework" in specs
+
+
+def test_schema_py_defines_class_edges():
+    """Every class should have a DEFINES_CLASS edge from the file."""
+    result = _parse(CODEGRAPH_PKG / "schema.py")
+    defines = [e for e in result.edges if e.kind == DEFINES_CLASS]
+    assert len(defines) == 17
+
+
+# ── mcp.py ground-truth ─────────────────────────────────────────────
+
+
+def test_mcp_py_ten_tool_decorators():
+    """mcp.py ships 10 `@mcp.tool()` tools — that count is load-bearing."""
+    result = _parse(CODEGRAPH_PKG / "mcp.py")
+    tool_edges = [
+        e for e in result.edges
+        if e.kind == DECORATED_BY and "mcp.tool" in e.dst_id
+    ]
+    assert len(tool_edges) == 10
+
+
+def test_mcp_py_module_functions():
+    """mcp.py has ~16 module-level functions (10 tools + helpers + main)."""
+    result = _parse(CODEGRAPH_PKG / "mcp.py")
+    assert len(result.functions) >= 12  # Conservative lower bound.
+
+
+# ── cli.py ground-truth ─────────────────────────────────────────────
+
+
+def test_cli_py_relative_imports():
+    """cli.py has at least 9 relative imports to sibling modules."""
+    result = _parse(CODEGRAPH_PKG / "cli.py")
+    relatives = [imp for imp in result.imports if imp.specifier.startswith(".")]
+    assert len(relatives) >= 9
+    specs = {imp.specifier for imp in relatives}
+    assert ".schema" in specs
+    assert ".resolver" in specs
+    assert ".utils.neo4j_json" in specs
+
+
+# ── config.py: try/except import branch ─────────────────────────────
+
+
+def test_config_py_try_except_import_captures_both_branches():
+    """config.py has:
+
+        try:
+            import tomllib
+        except ModuleNotFoundError:
+            import tomli
+
+    Both should be captured as separate ImportSpecs so a dependency query
+    sees both possibilities regardless of which one runs."""
+    result = _parse(CODEGRAPH_PKG / "config.py")
+    specs = {imp.specifier for imp in result.imports}
+    assert "tomllib" in specs
+    assert "tomli" in specs
+
+
+# ── Class-related assertions ────────────────────────────────────────
+
+
+def test_class_inheritance_captured():
+    """ConfigError inherits from Exception — class_extends should capture it."""
+    result = _parse(CODEGRAPH_PKG / "config.py")
+    # class_extends is list[tuple[class_name, base_name]]
+    pairs = dict(result.class_extends)
+    assert pairs.get("ConfigError") == "Exception"
+
+
+def test_enum_inheritance_abstract_flag_off():
+    """FrameworkType(Enum) is NOT abstract — only ABC / ABCMeta set that flag."""
+    result = _parse(CODEGRAPH_PKG / "framework.py")
+    fw = next((c for c in result.classes if c.name == "FrameworkType"), None)
+    assert fw is not None
+    assert fw.is_abstract is False
+
+
+def test_method_has_method_edge():
+    """Every method should emit a HAS_METHOD edge from its owner class."""
+    result = _parse(CODEGRAPH_PKG / "schema.py")
+    has_method = [e for e in result.edges if e.kind == HAS_METHOD]
+    # schema.py has 15 methods across its 17 classes.
+    assert len(has_method) == len(result.methods)
+    assert len(has_method) >= 10
+
+
+def test_init_method_flagged_as_constructor():
+    """`__init__` methods should have `is_constructor=True`."""
+    result = _parse(CODEGRAPH_PKG / "resolver.py")
+    inits = [m for m in result.methods if m.name == "__init__"]
+    assert len(inits) >= 2
+    for m in inits:
+        assert m.is_constructor is True
+
+
+def test_private_method_visibility():
+    """Methods starting with `_` (but not dunder) are marked private."""
+    result = _parse(CODEGRAPH_PKG / "resolver.py")
+    private = [m for m in result.methods if m.name.startswith("_") and not m.name.startswith("__")]
+    assert len(private) > 0
+    for m in private:
+        assert m.visibility == "private"
+
+
+def test_dunder_method_visibility_public():
+    """Dunder methods (`__enter__`, `__exit__`, etc.) are marked public."""
+    result = _parse(CODEGRAPH_PKG / "resolver.py")
+    inits = [m for m in result.methods if m.name == "__init__"]
+    for m in inits:
+        assert m.visibility == "public"
+
+
+# ── Import shape ────────────────────────────────────────────────────
+
+
+def test_aliased_import_captured():
+    """`import tree_sitter_typescript as tst` should yield a namespace alias."""
+    result = _parse(CODEGRAPH_PKG / "parser.py")
+    aliased = [imp for imp in result.imports if imp.namespace is not None]
+    assert len(aliased) >= 1
+    # The TS parser imports tree_sitter_typescript as tst.
+    names = {(imp.specifier, imp.namespace) for imp in aliased}
+    assert ("tree_sitter_typescript", "tst") in names
+
+
+def test_from_import_symbols_populated():
+    """`from typing import Any, Optional` should yield symbols=['Any','Optional']."""
+    result = _parse(CODEGRAPH_PKG / "mcp.py")
+    typing_imp = next((imp for imp in result.imports if imp.specifier == "typing"), None)
+    assert typing_imp is not None
+    assert "Any" in typing_imp.symbols
+    assert "Optional" in typing_imp.symbols
+
+
+# ── Synthetic edge cases (tmp_path) ─────────────────────────────────
+
+
+def test_async_function_parsed_as_function(tmp_path: Path):
+    """`async def foo():` should still register as a FunctionNode."""
+    src = 'async def fetch_data():\n    return 1\n'
+    f = tmp_path / "a.py"
+    f.write_text(src)
+    result = PyParser().parse_file(f, "a.py", "pkg")
+    # tree-sitter-python wraps async with its own node type; we skip async
+    # in Stage 1 but the file should still parse without crashing. We do NOT
+    # assert async functions are captured — that's an explicit Stage 1 non-goal.
+    assert result is not None
+
+
+def test_star_import_captured(tmp_path: Path):
+    """`from x import *` is rare but should not crash."""
+    f = tmp_path / "a.py"
+    f.write_text("from pkg import *\n")
+    result = PyParser().parse_file(f, "a.py", "pkg")
+    assert result is not None
+    assert len(result.imports) == 1
+    assert result.imports[0].symbols == ["*"]
+
+
+def test_relative_import_dotted(tmp_path: Path):
+    """`from ..utils.neo4j_json import clean_row` — double-dot + dotted path."""
+    f = tmp_path / "a.py"
+    f.write_text("from ..utils.neo4j_json import clean_row\n")
+    result = PyParser().parse_file(f, "a.py", "pkg")
+    assert result is not None
+    assert len(result.imports) == 1
+    assert result.imports[0].specifier == "..utils.neo4j_json"
+    assert result.imports[0].symbols == ["clean_row"]
+
+
+def test_bare_dots_relative_import(tmp_path: Path):
+    """`from . import foo` should yield specifier='.'"""
+    f = tmp_path / "a.py"
+    f.write_text("from . import foo\n")
+    result = PyParser().parse_file(f, "a.py", "pkg")
+    assert result is not None
+    assert len(result.imports) == 1
+    assert result.imports[0].specifier == "."
+    assert result.imports[0].symbols == ["foo"]
+
+
+def test_empty_file(tmp_path: Path):
+    f = tmp_path / "empty.py"
+    f.write_text("")
+    result = PyParser().parse_file(f, "empty.py", "pkg")
+    assert result is not None
+    assert len(result.classes) == 0
+    assert len(result.functions) == 0
+    assert len(result.imports) == 0
+
+
+def test_missing_file_returns_none(tmp_path: Path):
+    result = PyParser().parse_file(tmp_path / "nope.py", "nope.py", "pkg")
+    assert result is None

--- a/codegraph/tests/test_py_parser_calls.py
+++ b/codegraph/tests/test_py_parser_calls.py
@@ -1,0 +1,158 @@
+"""Receiver-classification tests for :meth:`PyParser._classify_py_call`.
+
+Each test parses a tiny synthetic Python source via ``tmp_path`` and asserts
+the resulting ``result.method_calls`` tuples. Only method-body calls are
+emitted — module-level function bodies are intentionally skipped (the
+resolver's Phase 4 can't wire them anyway).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codegraph.py_parser import PyParser
+
+
+def _parse_snippet(tmp_path: Path, source: str):
+    p = tmp_path / "snippet.py"
+    p.write_text(source, encoding="utf-8")
+    rel = "snippet.py"
+    parser = PyParser()
+    return parser.parse_file(p, rel, "pkg")
+
+
+def _calls(result):
+    # Return tuples stripped of caller_mid for easier assertion.
+    return [(kind, name, target) for (_mid, kind, name, target) in result.method_calls]
+
+
+def test_self_call_is_typed_this(tmp_path):
+    src = """
+class A:
+    def run(self):
+        self.foo()
+    def foo(self):
+        pass
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert ("this", "", "foo") in _calls(r)
+
+
+def test_self_field_call_is_this_field(tmp_path):
+    src = """
+class A:
+    def run(self):
+        self.svc.execute()
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert ("this.field", "svc", "execute") in _calls(r)
+
+
+def test_cls_call_maps_to_this(tmp_path):
+    """``cls.foo()`` inside a classmethod invokes MRO like ``self.foo()``."""
+    src = """
+class A:
+    @classmethod
+    def make(cls):
+        cls.foo()
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert ("this", "", "foo") in _calls(r)
+
+
+def test_super_call_is_super(tmp_path):
+    src = """
+class A:
+    def run(self):
+        super().run()
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert ("super", "", "run") in _calls(r)
+
+
+def test_bare_call_is_name(tmp_path):
+    src = """
+class A:
+    def run(self):
+        helper()
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert ("name", "", "helper") in _calls(r)
+
+
+def test_object_attribute_call_is_name_with_receiver(tmp_path):
+    src = """
+class A:
+    def run(self, obj):
+        obj.do()
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert ("name", "obj", "do") in _calls(r)
+
+
+def test_deep_chain_uses_last_segment_as_receiver(tmp_path):
+    """``a.b.c.m()`` records ``c`` as the best-effort receiver name."""
+    src = """
+class A:
+    def run(self, a):
+        a.b.c.m()
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert ("name", "c", "m") in _calls(r)
+
+
+def test_subscript_receiver_keeps_target_only(tmp_path):
+    src = """
+class A:
+    def run(self, items):
+        items[0].m()
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert ("name", "", "m") in _calls(r)
+
+
+def test_call_result_receiver_keeps_target_only(tmp_path):
+    src = """
+class A:
+    def run(self):
+        get_obj().m()
+"""
+    r = _parse_snippet(tmp_path, src)
+    calls = _calls(r)
+    # Both the outer .m() and the bare get_obj() call should appear.
+    assert ("name", "", "m") in calls
+    assert ("name", "", "get_obj") in calls
+
+
+def test_module_level_function_body_is_not_scanned(tmp_path):
+    """Resolver can't wire module-level callers — so we don't emit from them."""
+    src = """
+def outer():
+    helper()
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert _calls(r) == []
+
+
+def test_comprehension_calls_emitted(tmp_path):
+    """Descendant walk catches calls nested inside comprehensions."""
+    src = """
+class A:
+    def run(self, items):
+        [self.touch(x) for x in items]
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert ("this", "", "touch") in _calls(r)
+
+
+def test_staticmethod_body_still_scanned(tmp_path):
+    """No special-casing by decorator — static methods still emit calls."""
+    src = """
+class A:
+    @staticmethod
+    def helper():
+        other()
+"""
+    r = _parse_snippet(tmp_path, src)
+    assert ("name", "", "other") in _calls(r)

--- a/codegraph/tests/test_py_resolver.py
+++ b/codegraph/tests/test_py_resolver.py
@@ -19,7 +19,7 @@ from codegraph.resolver import (
     link_cross_file,
     load_python_package_config,
 )
-from codegraph.schema import IMPORTS, IMPORTS_SYMBOL
+from codegraph.schema import CALLS, IMPORTS, IMPORTS_SYMBOL
 
 
 # ── Helpers ─────────────────────────────────────────────────────────
@@ -230,3 +230,82 @@ def test_ts_import_unaffected_by_python_dispatch(tmp_path: Path):
     # The TS path would try pkg/a/../.b + TS extensions; none exist, so None.
     # (We just want no crash and no accidental Python resolution.)
     assert result is None or not result.endswith(".py")
+
+
+# ── Phase 4: method CALLS resolution (Python) ───────────────────────
+
+
+def _calls_edges(edges):
+    return [e for e in edges if e.kind == CALLS]
+
+
+def test_self_call_resolves_typed(tmp_path: Path):
+    """``self.foo()`` inside the same class → typed CALLS edge."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": (
+            "class A:\n"
+            "    def run(self):\n"
+            "        self.foo()\n"
+            "    def foo(self):\n"
+            "        pass\n"
+        ),
+    })
+    _, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+    calls = _calls_edges(edges)
+    assert any(
+        e.src_id == "method:class:pkg/a.py#A#run"
+        and e.dst_id == "method:class:pkg/a.py#A#foo"
+        and e.props.get("confidence") == "typed"
+        for e in calls
+    ), f"expected typed self.foo() edge; got {calls}"
+
+
+def test_super_call_resolves_to_parent(tmp_path: Path):
+    """``super().run()`` resolves via ``class_extends`` to the parent method."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/base.py": (
+            "class B:\n"
+            "    def run(self):\n"
+            "        pass\n"
+        ),
+        "pkg/child.py": (
+            "from .base import B\n"
+            "class A(B):\n"
+            "    def run(self):\n"
+            "        super().run()\n"
+        ),
+    })
+    _, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+    calls = _calls_edges(edges)
+    assert any(
+        e.src_id == "method:class:pkg/child.py#A#run"
+        and e.dst_id == "method:class:pkg/base.py#B#run"
+        and e.props.get("confidence") == "typed"
+        for e in calls
+    ), f"expected typed super().run() edge; got {calls}"
+
+
+def test_cls_call_resolves_like_self(tmp_path: Path):
+    """``cls.foo()`` inside a classmethod resolves to the enclosing class."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": (
+            "class A:\n"
+            "    @classmethod\n"
+            "    def make(cls):\n"
+            "        cls.foo()\n"
+            "    @classmethod\n"
+            "    def foo(cls):\n"
+            "        pass\n"
+        ),
+    })
+    _, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+    calls = _calls_edges(edges)
+    assert any(
+        e.src_id == "method:class:pkg/a.py#A#make"
+        and e.dst_id == "method:class:pkg/a.py#A#foo"
+        and e.props.get("confidence") == "typed"
+        for e in calls
+    ), f"expected typed cls.foo() edge; got {calls}"

--- a/codegraph/tests/test_py_resolver.py
+++ b/codegraph/tests/test_py_resolver.py
@@ -1,0 +1,232 @@
+"""Tests for Python import resolution in :mod:`codegraph.resolver`.
+
+Builds a synthetic Python package in ``tmp_path`` and runs the full
+``PyParser`` + ``Resolver`` + ``link_cross_file`` pipeline, inspecting the
+resulting edges. Exercises all three resolution rules: relative imports,
+absolute intra-package imports, and external fallback.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codegraph.py_parser import PyParser
+from codegraph.resolver import (
+    Index,
+    PathIndex,
+    Resolver,
+    link_cross_file,
+    load_python_package_config,
+)
+from codegraph.schema import IMPORTS, IMPORTS_SYMBOL
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _build_pkg(root: Path, files: dict[str, str]) -> None:
+    """Write each key→value under ``root``, creating parent dirs as needed."""
+    for rel, content in files.items():
+        f = root / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(content)
+
+
+def _run_pipeline(
+    repo_root: Path, package_name: str, package_dir: Path
+) -> tuple[Index, list]:
+    """Parse every .py under ``package_dir`` and run cross-file linking."""
+    parser = PyParser()
+    index = Index()
+    for p in package_dir.rglob("*.py"):
+        rel = str(p.resolve().relative_to(repo_root)).replace("\\", "/")
+        result = parser.parse_file(p, rel, package_name, is_test=False)
+        assert result is not None, f"failed to parse {rel}"
+        index.add(result)
+
+    pkg_config = load_python_package_config(repo_root, package_dir)
+    resolver = Resolver(repo_root, [pkg_config])
+    edges = link_cross_file(index, resolver)
+    return index, edges
+
+
+# ── Resolution rules ────────────────────────────────────────────────
+
+
+def test_relative_import_resolves(tmp_path: Path):
+    """`from .b import Bar` inside pkg/a.py → IMPORTS edge to pkg/b.py."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": "from .b import Bar\n",
+        "pkg/b.py": "class Bar:\n    pass\n",
+    })
+    index, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+
+    imports = [e for e in edges if e.kind == IMPORTS]
+    # Expect: a.py → b.py (intra-package)
+    resolved = [e for e in imports if not e.dst_id.startswith("external:")]
+    assert len(resolved) == 1
+    assert resolved[0].src_id == "file:pkg/a.py"
+    assert resolved[0].dst_id == "file:pkg/b.py"
+
+
+def test_absolute_intra_package_import_resolves(tmp_path: Path):
+    """`from pkg.c import Baz` inside pkg/a.py → IMPORTS edge to pkg/c.py."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": "from pkg.c import Baz\n",
+        "pkg/c.py": "class Baz:\n    pass\n",
+    })
+    index, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+
+    resolved = [e for e in edges if e.kind == IMPORTS and not e.dst_id.startswith("external:")]
+    assert len(resolved) == 1
+    assert resolved[0].src_id == "file:pkg/a.py"
+    assert resolved[0].dst_id == "file:pkg/c.py"
+
+
+def test_external_import_falls_through(tmp_path: Path):
+    """`from neo4j import GraphDatabase` → IMPORTS edge to :External."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": "from neo4j import GraphDatabase\n",
+    })
+    index, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+
+    imports = [e for e in edges if e.kind == IMPORTS]
+    assert len(imports) == 1
+    assert imports[0].dst_id == "external:neo4j"
+    # The external flag is set in props so the loader can apply the right label.
+    assert imports[0].props.get("external") is True
+
+
+def test_dotted_relative_import_walks_up(tmp_path: Path):
+    """`from ..b import Bar` inside pkg/sub/d.py → IMPORTS edge to pkg/b.py."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/b.py": "class Bar:\n    pass\n",
+        "pkg/sub/__init__.py": "",
+        "pkg/sub/d.py": "from ..b import Bar\n",
+    })
+    index, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+
+    resolved = [e for e in edges if e.kind == IMPORTS and not e.dst_id.startswith("external:")]
+    assert len(resolved) == 1
+    assert resolved[0].src_id == "file:pkg/sub/d.py"
+    assert resolved[0].dst_id == "file:pkg/b.py"
+
+
+def test_import_of_subpackage_as_file(tmp_path: Path):
+    """`from pkg.sub.d import X` — resolves pkg/sub/d.py as a .py file."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": "from pkg.sub.d import X\n",
+        "pkg/sub/__init__.py": "",
+        "pkg/sub/d.py": "class X:\n    pass\n",
+    })
+    index, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+
+    resolved = [e for e in edges if e.kind == IMPORTS and not e.dst_id.startswith("external:")]
+    assert any(e.dst_id == "file:pkg/sub/d.py" for e in resolved)
+
+
+def test_import_of_subpackage_as_init(tmp_path: Path):
+    """`from pkg.sub import foo` — resolves pkg/sub/__init__.py when no pkg/sub.py."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": "from pkg.sub import foo\n",
+        "pkg/sub/__init__.py": "foo = 1\n",
+    })
+    index, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+
+    resolved = [e for e in edges if e.kind == IMPORTS and not e.dst_id.startswith("external:")]
+    assert any(e.dst_id == "file:pkg/sub/__init__.py" for e in resolved)
+
+
+def test_walk_above_package_root_is_external(tmp_path: Path):
+    """A relative import that walks too many dots (`from ....way_too_far`) should
+    fall back to external rather than resolving to something outside the package."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": "from ....way_too_far import X\n",
+    })
+    index, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+
+    imports = [e for e in edges if e.kind == IMPORTS]
+    assert len(imports) == 1
+    # Either external, or resolved to something nonexistent (path-index miss → external).
+    assert imports[0].dst_id.startswith("external:")
+
+
+def test_bare_relative_from_import(tmp_path: Path):
+    """`from . import b` resolves to pkg/__init__.py (the package module)."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "b = 1\n",
+        "pkg/a.py": "from . import b\n",
+    })
+    index, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+
+    resolved = [e for e in edges if e.kind == IMPORTS and not e.dst_id.startswith("external:")]
+    assert any(e.dst_id == "file:pkg/__init__.py" for e in resolved)
+
+
+def test_imports_symbol_edges_emitted(tmp_path: Path):
+    """Each imported symbol gets its own IMPORTS_SYMBOL edge with the symbol
+    name in props."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": "from .b import Bar, Baz\n",
+        "pkg/b.py": "class Bar: pass\nclass Baz: pass\n",
+    })
+    index, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+
+    symbol_edges = [e for e in edges if e.kind == IMPORTS_SYMBOL]
+    symbols = {e.props.get("symbol") for e in symbol_edges}
+    assert "Bar" in symbols
+    assert "Baz" in symbols
+
+
+def test_import_statement_absolute(tmp_path: Path):
+    """`import pkg.b` → IMPORTS edge to pkg/b.py (dotted_name import)."""
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": "import pkg.b\n",
+        "pkg/b.py": "x = 1\n",
+    })
+    index, edges = _run_pipeline(tmp_path, "pkg", tmp_path / "pkg")
+
+    resolved = [e for e in edges if e.kind == IMPORTS and not e.dst_id.startswith("external:")]
+    assert any(e.dst_id == "file:pkg/b.py" for e in resolved)
+
+
+def test_ts_import_unaffected_by_python_dispatch(tmp_path: Path):
+    """Smoke test: a Resolver with no Python packages behaves exactly like
+    before (no _is_python_file true-case, Python dispatch never fires).
+
+    This protects the TS code path from the language-aware short-circuit we
+    added in :meth:`Resolver.resolve`.
+    """
+    _build_pkg(tmp_path, {
+        "pkg/__init__.py": "",
+        "pkg/a.py": "from .b import Bar\n",
+        "pkg/b.py": "class Bar: pass\n",
+    })
+    pkg_config = load_python_package_config(tmp_path, tmp_path / "pkg")
+    # Two resolvers: one aware of the Python package, one not.
+    py_aware = Resolver(tmp_path, [pkg_config])
+    no_pkg = Resolver(tmp_path, [])
+
+    fileset = {f"pkg/{n}" for n in ("__init__.py", "a.py", "b.py")}
+    py_aware.set_path_index(PathIndex(fileset))
+    no_pkg.set_path_index(PathIndex(fileset))
+
+    # Python-aware resolver resolves the relative import.
+    assert py_aware.resolve("pkg/a.py", ".b") == "pkg/b.py"
+    # No-package resolver falls into the TS code path and either returns
+    # None (no .ts/.tsx extension candidates match) or a non-Python file.
+    # Critically: it does NOT try Python rules and does NOT crash.
+    result = no_pkg.resolve("pkg/a.py", ".b")
+    # The TS path would try pkg/a/../.b + TS extensions; none exist, so None.
+    # (We just want no crash and no accidental Python resolution.)
+    assert result is None or not result.endswith(".py")


### PR DESCRIPTION
## Summary

Brings hotfix up to date with `dev`. 18 commits since the last sync, spanning Phase-1 Python indexing, framework detection, MCP stdio server, ignore rules, agent-native REPL, Claude Code wiring, and this session's additions:

- **Docstrings + signatures** on `:Function` / `:Method` nodes — populated straight from tree-sitter, no LLM in the indexer
- **CALLS edges** (function→function) with receiver classification: `self` / `cls` / `super` / bare / attribute / deep chains
- **MCP call-graph tools**: `calls_from`, `callers_of`, `describe_function`
- **Test-file pairing** unified between CLI and loader; graph-refresh scope now includes `codegraph/tests/`
- Function-level `@decorator` persistence bug fix (`@mcp.tool()` edges were being dropped)

Full list:
- chore(loader): unify test-file pairing + widen graph index scope
- feat(parser): emit Python CALLS edges + wire MCP call-graph tools
- feat(parser): extract docstrings, params, and return types for Python
- feat(claude): wire codegraph CLI into this repo's Claude Code setup
- feat(parser): index Python codebases via tree-sitter-python (Stage 1)
- docs(roadmap): session handoff document for continuing work across agents
- feat(mcp): add 5 pre-built retrievers for common agent questions
- fix(review): address code-reviewer findings across mcp, framework, tests
- fix(framework): detect NestJS, walk up for lockfile + workspace deps
- feat(mcp): stdio server with 5 read-only tools
- feat(schema): per-package framework detection + :Package nodes
- feat(ignore): .codegraphignore for per-repo file/route/component exclusion
- feat(cli): agent-native REPL, --json everywhere, pyproject packaging
- feat(config): un-hardcode Twenty, add codegraph.toml + pyproject.toml support
- docs(queries): expand Cypher query examples with schema overview
- wip: loader, parser, resolver, validate updates (x3)

## Test plan

- [x] `pytest tests/ -q` from `codegraph/` — **166 passed, 0 warnings** (~11s)
- [x] `codegraph index . -p codegraph --wipe` succeeds; live graph shows 192 CALLS edges, 50 Function docstrings, 54 Method docstrings
- [x] Function-level `@mcp.tool()` decorators now persist (was 0 on HEAD of hotfix, now 45)
- [ ] Reviewer: confirm no downstream tooling depends on the removed `RENDERS_COMPONENT` edge constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
