### PR TITLE
feat(mcp): expose queries.md as MCP prompt templates

### DIFF
--- a/codegraph/codegraph/mcp.py
+++ b/codegraph/codegraph/mcp.py
@@ -33,13 +33,101 @@ the graph.
 from __future__ import annotations
 
 import os
-from typing import Any, Optional
+import re
+from pathlib import Path
+from typing import Any, NamedTuple, Optional
 
 from mcp.server.fastmcp import FastMCP
 from neo4j import READ_ACCESS, Driver, GraphDatabase
 from neo4j.exceptions import ClientError, CypherSyntaxError, ServiceUnavailable
 
 from .utils.neo4j_json import clean_row
+
+
+# ── Query prompt helpers ─────────────────────────────────────────────
+
+_QUERIES_MD = Path(__file__).resolve().parent.parent / "queries.md"
+
+
+class _QueryEntry(NamedTuple):
+    name: str
+    description: str
+    cypher: str
+
+
+def _slugify(text: str) -> str:
+    """Convert a heading string to a URL-safe slug."""
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+
+
+def _parse_queries_md(text: str) -> list[_QueryEntry]:
+    """Parse fenced ```cypher blocks from *text* into a list of _QueryEntry objects.
+
+    Rules:
+    - Each ``## `` heading sets the current section name.
+    - Each ` ```cypher ` block under that heading becomes one entry.
+    - If multiple blocks share a heading, the second gets suffix ``-2``, etc.
+    - The first ``//`` comment line inside a block becomes the description;
+      otherwise the heading text is used.
+    """
+    entries: list[_QueryEntry] = []
+    heading: str = ""
+    heading_counts: dict[str, int] = {}
+    in_block = False
+    block_lines: list[str] = []
+
+    for line in text.splitlines():
+        if line.startswith("## "):
+            heading = line[3:].strip()
+        elif line.startswith("```cypher") and not in_block:
+            in_block = True
+            block_lines = []
+        elif line.startswith("```") and in_block:
+            in_block = False
+            cypher = "\n".join(block_lines).strip()
+            if not cypher or not heading:
+                continue
+            slug = _slugify(heading)
+            count = heading_counts.get(slug, 0) + 1
+            heading_counts[slug] = count
+            name = slug if count == 1 else f"{slug}-{count}"
+            # First // comment becomes description; fall back to heading
+            description = heading
+            for bl in block_lines:
+                stripped = bl.strip()
+                if stripped.startswith("//"):
+                    description = stripped.lstrip("/").strip()
+                    break
+            entries.append(_QueryEntry(name=name, description=description, cypher=cypher))
+        elif in_block:
+            block_lines.append(line)
+
+    return entries
+
+
+def _register_query_prompts(server: FastMCP) -> None:
+    """Register each Cypher block from queries.md as a FastMCP prompt."""
+    from mcp.server.fastmcp.prompts.base import Prompt
+
+    if not _QUERIES_MD.exists():
+        return
+
+    entries = _parse_queries_md(_QUERIES_MD.read_text(encoding="utf-8"))
+    for entry in entries:
+        cypher = entry.cypher
+        description = entry.description
+
+        def _make_fn(q: str):
+            def fn() -> str:
+                return q
+            return fn
+
+        prompt = Prompt.from_function(
+            _make_fn(cypher),
+            name=entry.name,
+            description=description,
+        )
+        server.add_prompt(prompt)
 
 
 # ── Configuration ───────────────────────────────────────────────────
@@ -123,6 +211,7 @@ def _run_read(cypher: str, **params: Any) -> list[dict]:
 # ── FastMCP server + tools ──────────────────────────────────────────
 
 mcp = FastMCP("codegraph")
+_register_query_prompts(mcp)
 
 
 @mcp.tool()

--- a/codegraph/tests/test_mcp.py
+++ b/codegraph/tests/test_mcp.py
@@ -490,3 +490,75 @@ def test_new_tools_surface_service_unavailable(monkeypatch, call):
         out = call()
     assert len(out) == 1 and "error" in out[0]
     assert "Neo4j is unreachable" in out[0]["error"]
+
+
+# ── query prompt parsing ─────────────────────────────────────────────
+
+
+def test_parse_queries_md_extracts_all_blocks():
+    """Real queries.md should yield exactly 29 entries."""
+    text = mcp_mod._QUERIES_MD.read_text(encoding="utf-8")
+    entries = mcp_mod._parse_queries_md(text)
+    assert len(entries) == 29
+
+
+def test_parse_queries_md_single_block_section():
+    md = "## My Section\n\n```cypher\n// My description\nMATCH (n) RETURN n\n```\n"
+    entries = mcp_mod._parse_queries_md(md)
+    assert len(entries) == 1
+    assert entries[0].name == "my-section"
+    assert entries[0].description == "My description"
+    assert "MATCH (n) RETURN n" in entries[0].cypher
+
+
+def test_parse_queries_md_multi_block_naming():
+    md = "## Foo\n\n```cypher\nRETURN 1\n```\n\n```cypher\nRETURN 2\n```\n\n```cypher\nRETURN 3\n```\n"
+    entries = mcp_mod._parse_queries_md(md)
+    assert [e.name for e in entries] == ["foo", "foo-2", "foo-3"]
+
+
+def test_parse_queries_md_comment_as_description():
+    md = "## Section\n\n```cypher\n// Explicit description\nMATCH (n) RETURN n\n```\n"
+    entries = mcp_mod._parse_queries_md(md)
+    assert entries[0].description == "Explicit description"
+
+
+def test_parse_queries_md_heading_fallback_when_no_comment():
+    md = "## My Heading\n\n```cypher\nMATCH (n) RETURN n\n```\n"
+    entries = mcp_mod._parse_queries_md(md)
+    assert entries[0].description == "My Heading"
+
+
+def test_parse_queries_md_empty_input():
+    assert mcp_mod._parse_queries_md("") == []
+
+
+def test_slugify():
+    assert mcp_mod._slugify("4. Impact analysis: who depends on X?") == "4-impact-analysis-who-depends-on-x"
+    assert mcp_mod._slugify("Schema overview") == "schema-overview"
+    assert mcp_mod._slugify("  Leading & trailing  ") == "leading-trailing"
+
+
+# ── query prompt registration ────────────────────────────────────────
+
+
+def test_query_prompts_registered_on_server():
+    prompts = mcp_mod.mcp._prompt_manager._prompts
+    assert len(prompts) >= 29
+
+
+def test_query_prompt_renders_cypher():
+    prompts = mcp_mod.mcp._prompt_manager._prompts
+    schema_prompt = prompts.get("schema-overview")
+    assert schema_prompt is not None
+    # Calling the underlying function returns the Cypher string
+    result = schema_prompt.fn()
+    assert "CALL db.labels()" in result
+
+
+def test_register_query_prompts_skips_missing_file(monkeypatch, tmp_path):
+    from mcp.server.fastmcp import FastMCP as _FastMCP
+    monkeypatch.setattr(mcp_mod, "_QUERIES_MD", tmp_path / "nonexistent.md")
+    fresh = _FastMCP("test")
+    mcp_mod._register_query_prompts(fresh)
+    assert len(fresh._prompt_manager._prompts) == 0


### PR DESCRIPTION
Closes #12

## Summary
- Exposed `queries.md` as MCP prompt templates via the `codegraph-mcp` stdio server
- Users can now retrieve curated Cypher query templates directly through the MCP protocol

## Test plan
- [x] Unit tests passed (267 passed, 1 deselected)
- [x] Code review clean
- [x] Critique PASS
- [x] Self-index verified (1380 files, 195 classes indexed)
- [x] Leytongo real-world test PASS
- [x] Arch check PASS

## Package
PyPI: cognitx-codegraph==0.1.2
Install: pip install cognitx-codegraph==0.1.2

Generated with [Claude Code](https://claude.com/claude-code)