### PR TITLE
fix(mcp): reject out-of-range limit/bool args in query_graph

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,14 +2,14 @@
 
 > **Purpose of this document.** Capture enough context for a fresh agent session (or a human returning after time away) to continue work on codegraph without re-deriving state from scratch. Separate from the user-facing roadmap bullets in `README.md`, which stay short and pitch-oriented.
 >
-> **Last updated:** 2026-04-17 after commits `af77cd3` → `fa031dd` (slash commands + arch-check CI + onboarding scaffolder + Python Stage 2 + MCP prompt templates + describe_schema CypherSyntaxError fix).
+> **Last updated:** 2026-04-17 after commits `af77cd3` → `10d7b0b` (slash commands + arch-check CI + onboarding scaffolder + Python Stage 2 + MCP prompt templates + describe_schema CypherSyntaxError fix + query_graph limit/bool validation).
 
 ---
 
 ## TL;DR — where we are
 
-- **Branch:** `archon/task-fix-issue-29-describe-schema-error`. Working tree clean. Fix for issue #29 committed as `fa031dd`.
-- **Tests:** 278 passing + 1 deselected (Docker-slow integration test), 0 warnings. Run via `.venv/bin/python -m pytest tests/ -q` from `codegraph/`.
+- **Branch:** `archon/task-fix-issue-30-query-graph-bool-limit`. Working tree clean. Fix for issue #30 committed as `10d7b0b`.
+- **Tests:** 280 passing + 1 deselected (Docker-slow integration test), 0 warnings. Run via `.venv/bin/python -m pytest tests/ -q` from `codegraph/`.
 - **Graph indexed:** Twenty CRM is currently loaded into the local Neo4j container at `bolt://localhost:7688` (13,473 files, 2,559 classes, 6,088 methods, 5,562 CALLS, 6,708 hook usages, 4,593 RENDERS).
 - **MCP server:** 13 read-only tools live + **29 prompt templates** (all Cypher blocks from `queries.md` auto-registered via `_register_query_prompts()`). `codegraph-mcp` console script registered. Smoke-tested via raw JSON-RPC.
 - **Package:** `cognitx-codegraph` v0.2.0 in `pyproject.toml`. Wheel + sdist build cleanly. **Not yet on PyPI** — needs one-time operational setup (Trusted Publisher registration).
@@ -22,6 +22,8 @@
 ## Shipped since the last roadmap update (commit `7588522`)
 
 ```
+10d7b0b fix(mcp):       reject out-of-range limit/bool args in query_graph instead of silently clamping (#30)
+11f02cb chore:          bump version to 0.1.4
 fa031dd fix(mcp):       catch CypherSyntaxError in describe_schema before ClientError (#29)
 eaee6a7 chore:          bump version to 0.1.3
 357ad03 feat(mcp):      expose queries.md as MCP prompt templates (#12)
@@ -40,6 +42,9 @@ edb8cca feat(parser):   extract docstrings, params, and return types for Python
 ```
 
 Four sessions' worth of work grouped by theme:
+
+### MCP bug fix: query_graph limit/bool validation (issue #30)
+- `10d7b0b fix(mcp)` — `query_graph()` in `mcp.py` (line 231) was the only one of 8 MCP tools that silently clamped out-of-range `limit` values (e.g. `limit=5000` → 1000) and accepted Python `bool` values (`True`/`False`) as limits instead of rejecting them. Replaced the inline 3-line guard (`isinstance` + `min()` cap) with the standard `_validate_limit(limit)` call, matching all 7 other tools. Also fixed the docstring (was "cap 1000", now "Integer in 1..1000") to match actual behaviour. Three test changes in `test_mcp.py`: updated error message in `test_query_graph_rejects_bad_limit`, converted `test_query_graph_caps_huge_limit` → `test_query_graph_rejects_huge_limit` (expects rejection, not capping), added parametrized `test_query_graph_rejects_bool_limit[True/False]`. Test count 278 → 280.
 
 ### MCP bug fix: describe_schema CypherSyntaxError (issue #29)
 - `fa031dd fix(mcp)` — `describe_schema()` in `mcp.py` now catches `CypherSyntaxError` before the broader `ClientError` handler, returning `{"error": "Cypher syntax error: ..."}` consistently. Matches the pattern already used in `_run_read()` and `query_graph()`. One new test (`test_describe_schema_surfaces_cypher_syntax_error`) added to `test_mcp.py` — injects a `CypherSyntaxError`, calls `describe_schema()`, asserts the error dict has the correct prefix and original message. Test count 277 → 278.
@@ -85,12 +90,12 @@ Beyond unit/integration tests, these were dogfooded against real systems:
 
 | Thing | Value |
 |---|---|
-| Current branch | `archon/task-fix-issue-29-describe-schema-error` |
+| Current branch | `archon/task-fix-issue-30-query-graph-bool-limit` |
 | Base branch | `main` |
-| Unpushed commits | 0 (working tree clean; `fa031dd` already committed) |
-| Open PR | #8 `dev → main` (the earlier work). Issue #29 fix branch pending merge. |
+| Unpushed commits | 0 (working tree clean; `10d7b0b` already committed) |
+| Open PR | #8 `dev → main` (the earlier work). Issue #30 fix branch pending merge. |
 | Working tree | Clean |
-| Test count | 278 passing + 1 deselected |
+| Test count | 280 passing + 1 deselected |
 | Test runtime | ~16 s |
 | Byte-compile | Clean |
 | Last editable install | After `357ad03`. Re-run `cd codegraph && .venv/bin/pip install -e .` after any `pyproject.toml` edit. |
@@ -435,7 +440,7 @@ asking. Do not merge the open PR #8 without asking.
 | `test_ignore.py` | 19 | `ignore.py` + cli helpers |
 | `test_framework.py` | 18 | `framework.py` (TS) |
 | `test_py_framework.py` | 13 | `framework.py` (Python Stage 2) |
-| `test_mcp.py` | 46 | `mcp.py` (13 tools + 29 prompts + describe_schema error handling) |
+| `test_mcp.py` | 49 | `mcp.py` (13 tools + 29 prompts + describe_schema/query_graph error handling) |
 | `test_py_parser.py` | 28 | `py_parser.py` (Stage 1 parsing) |
 | `test_py_parser_calls.py` | 12 | Method-body CALLS emission |
 | `test_py_parser_endpoints.py` | 18 | Python Stage 2 endpoint parsing |
@@ -447,7 +452,7 @@ asking. Do not merge the open PR #8 without asking.
 | `test_arch_config.py` | 20 | `.arch-policies.toml` parser (built-ins + custom + validation errors) |
 | `test_init.py` | 17 | Scaffolder helpers (detection, prompts, render, write) |
 | `test_init_integration.py` | 2 (1 slow) | End-to-end scaffold + optional Docker |
-| **Total** | **278** | |
+| **Total** | **280** | |
 
 ### Key decisions recorded in commit messages
 

--- a/codegraph/codegraph/mcp.py
+++ b/codegraph/codegraph/mcp.py
@@ -226,11 +226,11 @@ def query_graph(cypher: str, limit: int = 20) -> list[dict]:
     Args:
         cypher: Cypher query string. Example:
             ``MATCH (c:Class {is_controller:true}) RETURN c.name LIMIT 10``
-        limit: Maximum rows to return (default 20, cap 1000).
+        limit: Max rows to return. Integer in 1..1000, default 20.
     """
-    if not isinstance(limit, int) or limit < 1:
-        return [{"error": "limit must be a positive integer"}]
-    limit = min(limit, 1000)
+    err = _validate_limit(limit)
+    if err:
+        return [{"error": err}]
     try:
         with _read_session() as s:
             records = list(s.run(cypher))[:limit]

--- a/codegraph/pyproject.toml
+++ b/codegraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognitx-codegraph"
-version = "0.1.4"
+version = "0.1.5"
 description = "Code knowledge graph for Claude Code & AI coding agents — index TypeScript, Python, NestJS, FastAPI, React into Neo4j and query architecture in Cypher. Note: v0.2.0 is deprecated, use 0.1.x."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/codegraph/tests/test_mcp.py
+++ b/codegraph/tests/test_mcp.py
@@ -100,13 +100,20 @@ def test_query_graph_respects_limit(monkeypatch):
 def test_query_graph_rejects_bad_limit(monkeypatch):
     _patch(monkeypatch, [[{"n": 1}]])
     result = mcp_mod.query_graph("MATCH (n) RETURN n", limit=0)
-    assert result == [{"error": "limit must be a positive integer"}]
+    assert result == [{"error": "limit must be an integer in 1..1000"}]
 
 
-def test_query_graph_caps_huge_limit(monkeypatch):
+@pytest.mark.parametrize("bad", [True, False])
+def test_query_graph_rejects_bool_limit(monkeypatch, bad):
+    _patch(monkeypatch, [[{"n": 1}]])
+    result = mcp_mod.query_graph("MATCH (n) RETURN n", limit=bad)
+    assert result == [{"error": "limit must be an integer in 1..1000"}]
+
+
+def test_query_graph_rejects_huge_limit(monkeypatch):
     _patch(monkeypatch, [[{"n": i} for i in range(2000)]])
     out = mcp_mod.query_graph("MATCH (n) RETURN n", limit=5000)
-    assert len(out) == 1000  # capped
+    assert out == [{"error": "limit must be an integer in 1..1000"}]
 
 
 def test_query_graph_surfaces_client_error(monkeypatch):


### PR DESCRIPTION
Closes #30

## Summary
- `query_graph` MCP tool now validates `limit` (must be 1–1000) and boolean arguments, returning a clear error instead of silently clamping out-of-range values

## Test plan
- [x] Unit tests passed (280 passed)
- [x] Code review clean
- [x] Critique PASS
- [x] Self-index verified (1380 files, 195 classes indexed)
- [x] Leytongo real-world test PASS
- [x] Arch-check PASS (codegraph package clean)

## Package
PyPI: cognitx-codegraph==0.1.5
Install: pip install cognitx-codegraph==0.1.5

Generated with [Claude Code](https://claude.com/claude-code)