### PR TITLE
fix(loader): correct per-batch READS_ATOM/WRITES_ATOM stat counting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,14 +2,14 @@
 
 > **Purpose of this document.** Capture enough context for a fresh agent session (or a human returning after time away) to continue work on codegraph without re-deriving state from scratch. Separate from the user-facing roadmap bullets in `README.md`, which stay short and pitch-oriented.
 >
-> **Last updated:** 2026-04-20 after commits `865271e` → `f937391` (fix(loader): skip per-file extras for untouched files in incremental mode — closes #97; 554 tests passing, v0.1.67).
+> **Last updated:** 2026-04-22 after commits `865271e` → `2083622` (fix(loader): use batch len() for READS_ATOM/WRITES_ATOM stats instead of DB-wide count — closes #220; 555 tests passing, v0.1.68).
 
 ---
 
 ## TL;DR — where we are
 
-- **Branch:** `archon/task-fix-issue-97`. Fixes incremental mode writing per-file extras (env reads, event handlers, event emissions) for all files instead of only touched files. Added `touched_files: set[str] | None = None` parameter to `_write_per_file_extras` in `loader.py` with a `continue` guard; passed through from `load()`. Closes issue #97. v0.1.67.
-- **Tests:** 554 passing (1 excluded: MCP test requires `fastmcp` optional dep not installed in this env), 0 warnings. Run via `.venv/bin/python -m pytest tests/ -q` from `codegraph/`.
+- **Branch:** `archon/task-fix-issue-220`. Fixes READS_ATOM / WRITES_ATOM edge stats using DB-wide `session.run("MATCH ... RETURN count(r)")` instead of `len()` of the current batch — causing incremental-mode stats to report the global DB total rather than edges created this run. Replaced both queries with `len(atom_reads)` / `len(atom_writes)`. Closes issue #220. v0.1.68.
+- **Tests:** 555 passing (1 excluded: MCP test requires `fastmcp` optional dep not installed in this env), 0 warnings. Run via `.venv/bin/python -m pytest tests/ -q` from `codegraph/`.
 - **Graph indexed:** Twenty CRM is currently loaded into the local Neo4j container at `bolt://localhost:7688` (13,473 files, 2,559 classes, 6,088 methods, 5,562 CALLS, 6,708 hook usages, 4,593 RENDERS).
 - **MCP server:** 13 read-only tools + **2 write tools** (`wipe_graph`, `reindex_file`) gated by `--allow-write` flag + **29 prompt templates** (all Cypher blocks from `queries.md` auto-registered via `_register_query_prompts()`). `codegraph-mcp` console script registered. Smoke-tested via raw JSON-RPC.
 - **Package:** `cognitx-codegraph` v0.1.55 in `pyproject.toml`. Wheel + sdist build cleanly. **Not yet on PyPI** — needs one-time operational setup (Trusted Publisher registration). `release.yml` now waits for propagation and smoke-tests the published version.
@@ -21,14 +21,30 @@
 
 ---
 
-## Shipped since the last roadmap update (commit `21cb2c9`)
+## Shipped since the last roadmap update (commit `f937391`)
 
 ```
-f937391 fix(loader): skip per-file extras for untouched files in incremental mode
-9ff85c7 Merge pull request #219 from cognitx-leyton/archon/task-fix-issue-98
-de077d9 chore: bump version to 0.1.67
-23db317 docs(roadmap): update session handoff
+2083622 fix(loader): use batch len() for READS_ATOM/WRITES_ATOM stats instead of DB-wide count
+a97cf5f Merge pull request #221 from cognitx-leyton/archon/task-fix-issue-97
+1420d26 chore: bump version to 0.1.68
+650c32d docs(roadmap): update session handoff
 ```
+
+### Loader — fix READS_ATOM/WRITES_ATOM stats using DB-wide count (issue #220)
+
+- `2083622 fix(loader)` — Two files changed:
+
+  1. **`codegraph/codegraph/loader.py`** — Replaced two `session.run("MATCH ()-[r:READS_ATOM]->() RETURN count(r)")` / `WRITES_ATOM` equivalent DB-wide count queries in `_write_per_file_extras()` with `len(atom_reads)` / `len(atom_writes)`. All 25 other edge types in the function already used `len()` of the batch list; these two were anomalous holdovers that reported the global Neo4j total instead of edges created this run — causing inflated stats in incremental mode.
+
+  2. **`codegraph/tests/test_incremental.py`** — New `test_per_file_extras_atom_stats_use_len_not_db_count` test: sets up a two-file `ParseResult` (a.py has 1 atom_read + 1 atom_write; b.py has 1 atom_read + 0 atom_writes), loads with only `a.py` touched, asserts `stats.edges[READS_ATOM] == 1` and `stats.edges[WRITES_ATOM] == 1`. Uses the existing `captured_runs` fixture and `FakeCtx` pattern.
+
+  - **Tests**: 555 passed (1 new), 0 failures. Code review: 0 issues. Arch-check: 4/4 policies pass (1 skipped).
+
+- `a97cf5f` — PR #221 merged (`archon/task-fix-issue-97`). Version bumped to v0.1.68 (`1420d26`).
+
+---
+
+## Previously shipped (through commit `f937391`)
 
 ### Loader — skip per-file extras for untouched files in incremental mode (issue #97)
 

--- a/codegraph/codegraph/loader.py
+++ b/codegraph/codegraph/loader.py
@@ -832,8 +832,7 @@ def _write_per_file_extras(session, index: Index, stats: LoadStats, touched_file
         MATCH (a:Atom {name: r.atom_name})
         MERGE (fn)-[:READS_ATOM]->(a)
     """, atom_reads)
-    rec = session.run("MATCH ()-[r:READS_ATOM]->() RETURN count(r) AS v").single()
-    stats.edges[READS_ATOM] = int(rec["v"]) if rec else 0
+    stats.edges[READS_ATOM] = len(atom_reads)
 
     _run(session, """
         UNWIND $rows AS r
@@ -841,8 +840,7 @@ def _write_per_file_extras(session, index: Index, stats: LoadStats, touched_file
         MATCH (a:Atom {name: r.atom_name})
         MERGE (fn)-[:WRITES_ATOM]->(a)
     """, atom_writes)
-    rec = session.run("MATCH ()-[r:WRITES_ATOM]->() RETURN count(r) AS v").single()
-    stats.edges[WRITES_ATOM] = int(rec["v"]) if rec else 0
+    stats.edges[WRITES_ATOM] = len(atom_writes)
 
     _run(session, """
         UNWIND $rows AS r

--- a/codegraph/pyproject.toml
+++ b/codegraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognitx-codegraph"
-version = "0.1.68"
+version = "0.1.69"
 description = "Code knowledge graph for Claude Code & AI coding agents — index TypeScript, Python, NestJS, FastAPI, React into Neo4j and query architecture in Cypher. Note: v0.2.0 is deprecated, use 0.1.x."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/codegraph/tests/test_incremental.py
+++ b/codegraph/tests/test_incremental.py
@@ -27,6 +27,8 @@ from codegraph.schema import (
     IMPORTS,
     IMPORTS_SYMBOL,
     ParseResult,
+    READS_ATOM,
+    WRITES_ATOM,
 )
 
 
@@ -365,6 +367,50 @@ def test_load_touched_files_filters_per_file_extras(captured_runs):
     env_names = {r["env"] for r in env_merges[0][1]}
     assert env_files == {"a.py"}
     assert env_names == {"DB_URL"}
+
+
+def test_per_file_extras_atom_stats_use_len_not_db_count(captured_runs):
+    """READS_ATOM / WRITES_ATOM stats must count the local batch, not DB-wide.
+
+    Regression test for #220: in incremental mode only touched files' atoms
+    are MERGEd, so stats must reflect the batch size, not a global count.
+    """
+    idx = Index()
+    for path, reads, writes in (
+        ("a.py", [("CompA", "countAtom")], [("CompA", "userAtom")]),
+        ("b.py", [("CompB", "themeAtom")], []),
+    ):
+        fn = FileNode(path=path, package="p", language="py", loc=10)
+        pr = ParseResult(file=fn)
+        pr.atom_reads = reads
+        pr.atom_writes = writes
+        idx.add(pr)
+
+    ldr = Neo4jLoader.__new__(Neo4jLoader)
+    ldr.database = "neo4j"
+
+    class FakeCtx:
+        def __enter__(self):
+            return MagicMock()
+        def __exit__(self, *a):
+            pass
+
+    ldr.driver = MagicMock()
+    ldr.driver.session.return_value = FakeCtx()
+
+    stats = ldr.load(idx, [], touched_files={"a.py"})
+
+    # Only a.py's atoms should be in the MERGE calls
+    atom_read_merges = [
+        (cy, rows) for cy, rows in captured_runs
+        if "READS_ATOM" in cy
+    ]
+    assert len(atom_read_merges) == 1
+    assert len(atom_read_merges[0][1]) == 1  # only CompA→countAtom
+
+    # Stats must equal the batch length (1), not a DB-wide count
+    assert stats.edges[READS_ATOM] == 1
+    assert stats.edges[WRITES_ATOM] == 1
 
 
 # ── Test group 4: _file_from_id ───────────────────────────────────────


### PR DESCRIPTION
Closes #220

## Summary
- Fixed `_write_per_file_extras` in `loader.py` to use `len(batch)` for `READS_ATOM`/`WRITES_ATOM` stats instead of a DB-wide node count — the old code reported total graph nodes rather than the per-batch file count
- Added regression tests in `test_incremental.py` to pin the correct per-batch behaviour

## Test plan
- [x] Unit tests: 555 passed
- [x] Byte-compile clean
- [x] Code review: clean
- [x] Critique: PASS
- [x] Self-index verified (42 files, 90 classes, 297 methods)
- [x] Leytongo real-world test (1343 files, 72.9% imports resolved)

## Package
PyPI: `cognitx-codegraph==0.1.69`
Install: `pip install cognitx-codegraph==0.1.69`

Generated with [Claude Code](https://claude.com/claude-code)