### PR TITLE
fix(arch_check): exact suppression counts via Cypher for built-in policies

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,14 +2,14 @@
 
 > **Purpose of this document.** Capture enough context for a fresh agent session (or a human returning after time away) to continue work on codegraph without re-deriving state from scratch. Separate from the user-facing roadmap bullets in `README.md`, which stay short and pitch-oriented.
 >
-> **Last updated:** 2026-04-22 after commits `20fe092` → `b0e8739` (fix(arch-check): validate suppression policy names and suggest corrections — closes #94; 560 tests passing, v0.1.70).
+> **Last updated:** 2026-04-22 after commits `2460d3a` → `archon/task-fix-issue-93` (fix(arch-check): exact suppression counts via Cypher COUNT filter — closes #93; 573 tests passing, v0.1.71).
 
 ---
 
 ## TL;DR — where we are
 
-- **Branch:** `archon/task-fix-issue-94`. Validates suppression policy names at config-load time in `arch_config.py` — unknown names now raise a `ConfigError` with a "did you mean?" suggestion (via `difflib.get_close_matches`) or the full list of known policies. Closes issue #94. v0.1.70.
-- **Tests:** 560 passing (1 excluded: MCP test requires `fastmcp` optional dep not installed in this env), 0 warnings. Run via `.venv/bin/python -m pytest tests/ -q` from `codegraph/`.
+- **Branch:** `archon/task-fix-issue-93`. Suppression matching now uses Cypher COUNT filter for exact unsuppressed totals — `_count_unsuppressed()` dispatcher + 5 per-policy filtered count builders added to `arch_check.py`. `_apply_suppressions()` accepts `driver=`, `scope=`, `config=` kwargs and uses exact counts when a driver is available, with sample-based fallback otherwise. Closes issue #93. v0.1.71.
+- **Tests:** 573 passing (1 excluded: MCP test requires `fastmcp` optional dep not installed in this env), 0 warnings. Run via `.venv/bin/python -m pytest tests/ -q` from `codegraph/`.
 - **Graph indexed:** Twenty CRM is currently loaded into the local Neo4j container at `bolt://localhost:7688` (13,473 files, 2,559 classes, 6,088 methods, 5,562 CALLS, 6,708 hook usages, 4,593 RENDERS).
 - **MCP server:** 13 read-only tools + **2 write tools** (`wipe_graph`, `reindex_file`) gated by `--allow-write` flag + **29 prompt templates** (all Cypher blocks from `queries.md` auto-registered via `_register_query_prompts()`). `codegraph-mcp` console script registered. Smoke-tested via raw JSON-RPC.
 - **Package:** `cognitx-codegraph` v0.1.55 in `pyproject.toml`. Wheel + sdist build cleanly. **Not yet on PyPI** — needs one-time operational setup (Trusted Publisher registration). `release.yml` now waits for propagation and smoke-tests the published version.
@@ -21,13 +21,29 @@
 
 ---
 
-## Shipped since the last roadmap update (commit `20fe092`)
+## Shipped since the last roadmap update (commit `2460d3a`)
 
 ```
-b0e8739 fix(arch-check): validate suppression policy names and suggest corrections
-0829e4d Merge pull request #223 from cognitx-leyton/archon/task-fix-issue-96
-b001c70 chore: bump version to 0.1.70
+archon/task-fix-issue-93  fix(arch-check): exact suppression counts via Cypher COUNT filter
+bbc12fd  Merge pull request #224 from cognitx-leyton/archon/task-fix-issue-94
+e1bdcd0  chore: bump version to 0.1.71
+2460d3a  docs(roadmap): update session handoff
+b0e8739  fix(arch-check): validate suppression policy names and suggest corrections
 ```
+
+### arch-check — exact suppression counts via Cypher COUNT filter (issue #93)
+
+- `archon/task-fix-issue-93` — Two files changed:
+
+  1. **`codegraph/codegraph/arch_check.py`** — Added `_count_unsuppressed()` dispatcher function + 5 per-policy filtered count builders (`_count_unsuppressed_coupling`, `_count_unsuppressed_cross_package`, `_count_unsuppressed_layer_bypass`, `_count_unsuppressed_orphans`, `_count_unsuppressed_import_cycles`). Each mirrors the original `_check_*` count query but adds `WHERE NOT ... IN $suppressed_keys` clauses so the Neo4j engine filters suppressed rows before counting. Returns `None` for custom policies (fallback). Refactored `_apply_suppressions()` with new optional `driver=`, `scope=`, `config=` kwargs; when driver is available, calls `_count_unsuppressed()` for exact remaining counts instead of relying on sample-subtraction heuristics. Moved `_apply_suppressions` call inside the `try` block in `run_arch_check()` so the driver is still open, passing `driver=`, `scope=`, `config=`.
+
+  2. **`codegraph/tests/test_arch_check.py`** — 15 new tests:
+     - 8 `_count_unsuppressed` unit tests (one per built-in policy + custom returns `None` + scope threading)
+     - 4 `_apply_suppressions` scenario tests (issue #93 exact count, partial count, custom policy fallback, driver path sets no `incomplete_suppression_coverage` flag)
+     - 1 integration test `test_run_arch_check_suppression_exact_count_integration` (50 violations, all suppressed, count=0)
+     - Updated 2 existing integration tests to handle filtered count queries in the fake driver
+
+  - **Tests**: 82/82 in `test_arch_check.py` (15 new), 573/573 full suite, 0 failures. Code review: 0 issues. Arch-check: 4/4 policies pass (1 skipped).
 
 ### arch-check — validate suppression policy names at config load time (issue #94)
 
@@ -41,9 +57,9 @@ b001c70 chore: bump version to 0.1.70
      - `test_suppression_custom_policy_name_accepted`: custom policy `"no_fat_files"` in both `[[policy]]` and `[[suppress]]` loads cleanly.
      - `test_suppression_typo_of_custom_policy_rejected`: `"no_fat_file"` (off-by-one) is caught as unknown with a suggestion.
 
-  - **Tests**: 57/57 in `test_arch_config.py` (4 new), 560/560 full suite, 0 failures. Code review: 0 issues. Arch-check: 4/4 policies pass (1 skipped).
+  - **Tests**: 57/57 in `test_arch_config.py` (4 new), 560/560 full suite (pre-#93), 0 failures. Code review: 0 issues. Arch-check: 4/4 policies pass (1 skipped).
 
-- `0829e4d` — PR #223 merged (`archon/task-fix-issue-96`). Version bumped to v0.1.70 (`b001c70`).
+- `bbc12fd` — PR #224 merged (`archon/task-fix-issue-94`). Version bumped to v0.1.71 (`e1bdcd0`).
 
 ---
 

--- a/codegraph/codegraph/arch_check.py
+++ b/codegraph/codegraph/arch_check.py
@@ -134,14 +134,16 @@ def run_arch_check(
     sample_limit = config.sample_limit
 
     driver = GraphDatabase.driver(uri, auth=(user, password))
+    stale: list[dict] = []
     try:
         policies = _run_all(driver, config, scope, sample_limit)
+        if config.suppressions:
+            policies, stale = _apply_suppressions(
+                policies, config.suppressions, sample_limit,
+                driver=driver, scope=scope, config=config,
+            )
     finally:
         driver.close()
-
-    stale: list[dict] = []
-    if config.suppressions:
-        policies, stale = _apply_suppressions(policies, config.suppressions, sample_limit)
 
     report = ArchReport(policies=policies, stale_suppressions=stale)
     if console is not None:
@@ -503,6 +505,235 @@ def _check_custom(
     )
 
 
+# ── Exact suppression counting ─────────────────────────────
+
+
+def _count_unsuppressed(
+    driver: Driver,
+    policy_name: str,
+    suppressed_keys: list[str],
+    scope: list[str] | None,
+    config: ArchConfig,
+) -> int | None:
+    """Return the exact unsuppressed violation count for a built-in policy.
+
+    Builds a filtered Cypher ``COUNT`` query that mirrors the original
+    ``_check_*`` count query but adds ``WHERE NOT`` clauses to exclude
+    violations whose keys appear in *suppressed_keys*.  Returns ``None``
+    for custom (user-authored) policies — those fall back to Python-side
+    sample counting in :func:`_apply_suppressions`.
+    """
+    if policy_name == "coupling_ceiling":
+        return _count_unsuppressed_coupling(driver, suppressed_keys, scope, config.coupling_ceiling)
+    if policy_name == "cross_package":
+        return _count_unsuppressed_cross_package(driver, suppressed_keys, scope, config.cross_package)
+    if policy_name == "layer_bypass":
+        return _count_unsuppressed_layer_bypass(driver, suppressed_keys, scope, config.layer_bypass)
+    if policy_name == "orphan_detection":
+        return _count_unsuppressed_orphans(driver, suppressed_keys, scope, config.orphan_detection)
+    if policy_name == "import_cycles":
+        return _count_unsuppressed_import_cycles(driver, suppressed_keys, scope, config.import_cycles)
+    # Custom / unknown policy — caller falls back to Python counting.
+    return None
+
+
+def _count_unsuppressed_coupling(
+    driver: Driver, suppressed_keys: list[str],
+    scope: list[str] | None, cfg: CouplingCeilingConfig,
+) -> int:
+    scope_frag, scope_params = _scope_filter("f", "path", scope)
+    where = f"WHERE {scope_frag}\n" if scope_frag else ""
+    cypher = (
+        "MATCH (f:File)-[:IMPORTS]->(g:File)\n"
+        f"{where}"
+        "WITH f, count(g) AS deps\n"
+        "WHERE deps > $threshold\n"
+        "  AND NOT f.path IN $suppressed_keys\n"
+        "RETURN count(f) AS v"
+    )
+    with driver.session() as s:
+        return int(s.run(cypher, threshold=cfg.max_imports,
+                         suppressed_keys=suppressed_keys, **scope_params).single()["v"] or 0)
+
+
+def _count_unsuppressed_cross_package(
+    driver: Driver, suppressed_keys: list[str],
+    scope: list[str] | None, cfg: CrossPackageConfig,
+) -> int:
+    scope_frag, scope_params = _scope_filter("a", "path", scope)
+    scope_clause = f" AND {scope_frag}" if scope_frag else ""
+    total = 0
+    with driver.session() as s:
+        for pair in cfg.pairs:
+            count = int(s.run(
+                "MATCH (a:File)-[:IMPORTS]->(b:File) "
+                "WHERE a.package = $a AND b.package = $b"
+                f"{scope_clause} "
+                "AND NOT (a.path + ' -> ' + b.path) IN $suppressed_keys "
+                "RETURN count(*) AS v",
+                a=pair.importer, b=pair.importee,
+                suppressed_keys=suppressed_keys, **scope_params,
+            ).single()["v"] or 0)
+            total += count
+    return total
+
+
+def _count_unsuppressed_layer_bypass(
+    driver: Driver, suppressed_keys: list[str],
+    scope: list[str] | None, cfg: LayerBypassConfig,
+) -> int:
+    labels_or = "|".join(cfg.controller_labels)
+    depth = f"*1..{cfg.call_depth}"
+    scope_frag, scope_params = _scope_filter("ctrl", "file", scope)
+    scope_clause = f"  AND {scope_frag}\n" if scope_frag else ""
+    cypher = (
+        f"MATCH (ctrl:{labels_or})-[:HAS_METHOD]->(m:Method)"
+        f"-[:CALLS{depth}]->(target:Method)\n"
+        f"MATCH (repo:Class)-[:HAS_METHOD]->(target)\n"
+        f"WHERE repo.name ENDS WITH $repo_suffix\n"
+        f"{scope_clause}"
+        f"  AND NOT EXISTS {{\n"
+        f"    MATCH (ctrl)-[:HAS_METHOD]->(:Method)-[:CALLS{depth}]->(:Method)"
+        f"<-[:HAS_METHOD]-(svc:Class)\n"
+        f"    WHERE svc.name ENDS WITH $svc_suffix\n"
+        f"  }}\n"
+        f"  AND NOT (ctrl.name + ' -> ' + repo.name + '.' + target.name) IN $suppressed_keys\n"
+        f"RETURN count(DISTINCT ctrl) AS v"
+    )
+    with driver.session() as s:
+        return int(s.run(
+            cypher,
+            repo_suffix=cfg.repository_suffix,
+            svc_suffix=cfg.service_suffix,
+            suppressed_keys=suppressed_keys,
+            **scope_params,
+        ).single()["v"] or 0)
+
+
+def _count_unsuppressed_orphans(
+    driver: Driver, suppressed_keys: list[str],
+    scope: list[str] | None, cfg: OrphanDetectionConfig,
+) -> int:
+    _kind_queries = {
+        "function": (
+            "MATCH (f:Function)\n"
+            "WHERE NOT EXISTS { ()-[:CALLS]->(f) }\n"
+            "  AND NOT EXISTS { ()-[:RENDERS]->(f) }\n"
+            "  AND NOT EXISTS { (f)-[:DECORATED_BY]->(:Decorator) }\n"
+            "  AND NOT f.name STARTS WITH 'test_'\n"
+            "  AND NOT f.name IN ['setup_module', 'teardown_module',\n"
+            "                     'setup_function', 'teardown_function',\n"
+            "                     'setup_class', 'teardown_class',\n"
+            "                     'setup_method', 'teardown_method']\n"
+            "{prefix_filter}"
+            "  AND NOT ('orphan_function:' + f.name) IN $suppressed_keys\n"
+            "RETURN 'orphan_function' AS kind, f.name AS name, f.file AS file"
+        ),
+        "class": (
+            "MATCH (c:Class)\n"
+            "WHERE NOT EXISTS { ()-[:EXTENDS]->(c) }\n"
+            "  AND NOT EXISTS { ()-[:INJECTS]->(c) }\n"
+            "  AND NOT EXISTS { ()-[:RESOLVES]->(c) }\n"
+            "  AND NOT EXISTS { (:File)-[:IMPORTS_SYMBOL {symbol: c.name}]->(:File) }\n"
+            "{prefix_filter}"
+            "  AND NOT ('orphan_class:' + c.name) IN $suppressed_keys\n"
+            "RETURN 'orphan_class' AS kind, c.name AS name, c.file AS file"
+        ),
+        "atom": (
+            "MATCH (a:Atom)\n"
+            "WHERE NOT EXISTS { ()-[:READS_ATOM]->(a) }\n"
+            "  AND NOT EXISTS { ()-[:WRITES_ATOM]->(a) }\n"
+            "{prefix_filter}"
+            "  AND NOT ('orphan_atom:' + a.name) IN $suppressed_keys\n"
+            "RETURN 'orphan_atom' AS kind, a.name AS name, a.file AS file"
+        ),
+        "endpoint": (
+            "MATCH (e:Endpoint)\n"
+            "WHERE NOT EXISTS { (:Method)-[:HANDLES]->(e) }\n"
+            "{prefix_filter}"
+            "  AND NOT ('orphan_endpoint:' + e.method + ' ' + e.path) IN $suppressed_keys\n"
+            "RETURN 'orphan_endpoint' AS kind, "
+            "(e.method + ' ' + e.path) AS name, e.file AS file"
+        ),
+    }
+    _kind_var = {"function": "f", "class": "c", "atom": "a", "endpoint": "e"}
+
+    scope_extra: dict = {}
+    parts: list[str] = []
+    for kind in cfg.kinds:
+        tmpl = _kind_queries[kind]
+        if cfg.path_prefix:
+            pf = f"  AND {_kind_var[kind]}.file STARTS WITH $prefix\n"
+        elif scope:
+            sf, sp = _scope_filter(_kind_var[kind], "file", scope)
+            pf = f"  AND {sf}\n"
+            scope_extra.update(sp)
+        else:
+            pf = ""
+        parts.append(tmpl.replace("{prefix_filter}", pf))
+
+    union = "\nUNION ALL\n".join(parts)
+    cypher = f"CALL () {{\n{union}\n}}\nRETURN count(*) AS v"
+
+    params: dict = {"suppressed_keys": suppressed_keys}
+    if cfg.path_prefix:
+        params["prefix"] = cfg.path_prefix
+    params.update(scope_extra)
+
+    with driver.session() as s:
+        return int(s.run(cypher, **params).single()["v"] or 0)
+
+
+def _count_unsuppressed_import_cycles(
+    driver: Driver, suppressed_keys: list[str],
+    scope: list[str] | None, cfg: ImportCyclesConfig,
+) -> int:
+    hops = f"*{cfg.min_hops}..{cfg.max_hops}"
+    scope_frag, scope_params = _scope_filter("a", "path", scope)
+    where = f"WHERE {scope_frag}\n" if scope_frag else ""
+
+    # Separate edge-pair keys ("A -> B") from full-cycle keys ("A -> B -> C -> A").
+    edge_pairs: list[list[str]] = []
+    full_cycle_keys: list[str] = []
+    for key in suppressed_keys:
+        parts = [p.strip() for p in key.split(" -> ")]
+        if len(parts) == 2:
+            edge_pairs.append(parts)
+        else:
+            full_cycle_keys.append(key)
+
+    # Build WHERE NOT clauses for each type.
+    filters: list[str] = []
+    params: dict = {**scope_params}
+    if edge_pairs:
+        filters.append(
+            "NONE(pair IN $edge_pairs WHERE\n"
+            "  ANY(i IN range(0, size(cycle)-2) WHERE cycle[i] = pair[0] AND cycle[i+1] = pair[1]))"
+        )
+        params["edge_pairs"] = edge_pairs
+    if full_cycle_keys:
+        filters.append(
+            "NOT reduce(s = '', x IN cycle | s + CASE WHEN s = '' THEN '' ELSE ' -> ' END + x)"
+            " IN $full_cycle_keys"
+        )
+        params["full_cycle_keys"] = full_cycle_keys
+
+    filter_clause = ""
+    if filters:
+        filter_clause = "  AND " + "\n  AND ".join(filters) + "\n"
+
+    cypher = (
+        f"MATCH path = (a:File)-[:IMPORTS{hops}]->(a)\n"
+        f"{where}"
+        f"WITH [n IN nodes(path) | n.path] AS cycle, path\n"
+        f"WHERE size(cycle) > 0\n"
+        f"{filter_clause}"
+        f"RETURN count(DISTINCT path) AS v"
+    )
+    with driver.session() as s:
+        return int(s.run(cypher, **params).single()["v"] or 0)
+
+
 # ── Suppression matching ────────────────────────────────────
 
 
@@ -557,8 +788,17 @@ def _apply_suppressions(
     policies: list[PolicyResult],
     suppressions: list[Suppression],
     sample_limit: int = 10,
+    *,
+    driver: Driver | None = None,
+    scope: list[str] | None = None,
+    config: ArchConfig | None = None,
 ) -> tuple[list[PolicyResult], list[dict]]:
     """Match suppressions against policy results.
+
+    When *driver* and *config* are provided the function queries Neo4j for
+    the exact unsuppressed count (built-in policies only).  Without a
+    driver it falls back to sample-based subtraction — the pre-#93
+    behaviour.
 
     Returns ``(updated_policies, stale_suppressions)``.
     """
@@ -599,22 +839,29 @@ def _apply_suppressions(
                 kept.append(row)
 
         suppressed_count = len(suppressed)
-        new_violation_count = max(0, p.violation_count - suppressed_count)
-        incomplete = (
-            p.violation_count > len(p.sample)
-            and suppressed_count > 0
-        )
-        # Invariant: incomplete=True implies passed=False.
-        # Suppressed rows are drawn from the sample, so
-        # suppressed_count <= len(sample) < violation_count (when
-        # incomplete is True), therefore new_violation_count > 0.
-        assert not (incomplete and new_violation_count == 0), (
-            f"invariant violated: incomplete_suppression_coverage={incomplete} "
-            f"but new_violation_count={new_violation_count}"
-        )
-        # Only mark as passing when the full violation count is accounted
-        # for.  When violation_count > len(sample) we can't be certain that
-        # unseen violations beyond the sample window are also suppressed.
+
+        # Try exact Cypher count when a driver is available.
+        exact_count: int | None = None
+        if driver is not None and config is not None:
+            exact_count = _count_unsuppressed(
+                driver, p.name,
+                [s.key for s in policy_supps],
+                scope, config,
+            )
+
+        if exact_count is not None:
+            # Authoritative count from Neo4j — no guessing.
+            new_violation_count = exact_count
+            incomplete = False
+        else:
+            # Fallback: sample-based subtraction (custom policies, or
+            # no driver).
+            new_violation_count = max(0, p.violation_count - suppressed_count)
+            incomplete = (
+                p.violation_count > len(p.sample)
+                and suppressed_count > 0
+            )
+
         updated.append(PolicyResult(
             name=p.name,
             passed=(new_violation_count == 0),

--- a/codegraph/pyproject.toml
+++ b/codegraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognitx-codegraph"
-version = "0.1.71"
+version = "0.1.72"
 description = "Code knowledge graph for Claude Code & AI coding agents — index TypeScript, Python, NestJS, FastAPI, React into Neo4j and query architecture in Cypher. Note: v0.2.0 is deprecated, use 0.1.x."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/codegraph/tests/test_arch_check.py
+++ b/codegraph/tests/test_arch_check.py
@@ -741,6 +741,7 @@ def test_run_arch_check_passes_scope_to_policies(monkeypatch):
 
 from codegraph.arch_check import (
     _apply_suppressions,
+    _count_unsuppressed,
     _match_suppression_key,
     _violation_key,
 )
@@ -894,7 +895,7 @@ def test_apply_suppressions_empty_list_is_noop():
 
 
 def test_apply_suppressions_incomplete_coverage_when_truncated():
-    """Flag set when violation_count > len(sample) and suppressions match."""
+    """Flag set when violation_count > len(sample) and no driver (fallback)."""
     sample = [{"file": f"f{i}.ts", "deps": 20 + i} for i in range(10)]
     policies = [
         PolicyResult(
@@ -907,6 +908,7 @@ def test_apply_suppressions_incomplete_coverage_when_truncated():
     supps = [
         Suppression(policy="coupling_ceiling", key="f0.ts", reason="ok"),
     ]
+    # No driver → falls back to sample-based counting → incomplete flag.
     updated, stale = _apply_suppressions(policies, supps)
     p = updated[0]
     assert p.incomplete_suppression_coverage is True
@@ -961,7 +963,7 @@ def test_apply_suppressions_no_incomplete_flag_when_no_suppression_matches():
 
 
 def test_invariant_incomplete_implies_not_passed():
-    """Invariant: incomplete_suppression_coverage=True implies passed=False.
+    """Without driver: incomplete_suppression_coverage=True → passed=False.
 
     When violation_count > len(sample) and all sample rows are suppressed,
     unseen violations beyond the sample window keep passed=False.
@@ -979,6 +981,7 @@ def test_invariant_incomplete_implies_not_passed():
         Suppression(policy="coupling_ceiling", key=f"f{i}.ts", reason="ok")
         for i in range(10)
     ]
+    # No driver → fallback to sample-based counting.
     updated, _stale = _apply_suppressions(policies, supps)
     p = updated[0]
     assert p.incomplete_suppression_coverage is True
@@ -1064,19 +1067,268 @@ def test_render_no_warning_when_coverage_complete():
     assert "suppression coverage is partial" not in output
 
 
+# ── Issue #93 scenario tests ────────────────────────────────────
+
+
+def test_apply_suppressions_exact_count_beyond_sample_window():
+    """Issue #93: 50 violations, sample=10, key matches all 50 → count=0."""
+    sample = [{"file": f"f{i}.ts", "deps": 20 + i} for i in range(10)]
+    policies = [
+        PolicyResult(
+            name="coupling_ceiling",
+            passed=False,
+            violation_count=50,  # 50 total violations
+            sample=sample,       # only 10 in sample
+        ),
+    ]
+    supps = [
+        Suppression(policy="coupling_ceiling", key=f"f{i}.ts", reason="ok")
+        for i in range(50)  # keys for all 50
+    ]
+    # Driver returns 0 for the filtered count query.
+    driver = _FakeDriver(lambda cypher, **p: [{"v": 0}])
+    config = ArchConfig()
+    updated, stale = _apply_suppressions(
+        policies, supps, driver=driver, config=config,
+    )
+    p = updated[0]
+    assert p.violation_count == 0  # EXACT, not 50 - 10 = 40
+    assert p.passed is True
+    assert p.incomplete_suppression_coverage is False
+
+
+def test_apply_suppressions_exact_count_partial():
+    """50 violations, sample=10, Cypher says 20 unsuppressed → count=20."""
+    sample = [{"file": f"f{i}.ts", "deps": 20 + i} for i in range(10)]
+    policies = [
+        PolicyResult(
+            name="coupling_ceiling",
+            passed=False,
+            violation_count=50,
+            sample=sample,
+        ),
+    ]
+    supps = [
+        Suppression(policy="coupling_ceiling", key=f"f{i}.ts", reason="ok")
+        for i in range(30)
+    ]
+    driver = _FakeDriver(lambda cypher, **p: [{"v": 20}])
+    config = ArchConfig()
+    updated, _stale = _apply_suppressions(
+        policies, supps, driver=driver, config=config,
+    )
+    p = updated[0]
+    assert p.violation_count == 20  # from Cypher, not 50 - sample_matches
+    assert p.passed is False
+    assert p.incomplete_suppression_coverage is False
+
+
+def test_apply_suppressions_custom_policy_keeps_sample_counting():
+    """Custom policies still use sample-based counting (no Cypher filter)."""
+    sample = [{"path": f"f{i}.py", "loc": 500 + i} for i in range(5)]
+    policies = [
+        PolicyResult(
+            name="my_custom",
+            passed=False,
+            violation_count=10,
+            sample=sample,
+        ),
+    ]
+    supps = [
+        Suppression(policy="my_custom", key="f0.py | 500", reason="ok"),
+    ]
+    # Driver provided but _count_unsuppressed returns None for custom → fallback.
+    driver = _FakeDriver(lambda cypher, **p: [{"v": 999}])  # should not be used
+    config = ArchConfig()
+    updated, _stale = _apply_suppressions(
+        policies, supps, driver=driver, config=config,
+    )
+    p = updated[0]
+    # Sample-based: 10 - 1 = 9 (not the 999 from the driver).
+    assert p.violation_count == 9
+    assert p.passed is False
+    assert p.incomplete_suppression_coverage is True  # 10 > 5 sample rows
+
+
+def test_apply_suppressions_with_driver_no_incomplete_flag():
+    """With driver, incomplete_suppression_coverage is False for built-in."""
+    sample = [{"file": f"f{i}.ts", "deps": 20 + i} for i in range(10)]
+    policies = [
+        PolicyResult(
+            name="coupling_ceiling",
+            passed=False,
+            violation_count=20,
+            sample=sample,
+        ),
+    ]
+    supps = [
+        Suppression(policy="coupling_ceiling", key="f0.ts", reason="ok"),
+    ]
+    # Driver returns 19 unsuppressed.
+    driver = _FakeDriver(lambda cypher, **p: [{"v": 19}])
+    config = ArchConfig()
+    updated, _stale = _apply_suppressions(
+        policies, supps, driver=driver, config=config,
+    )
+    p = updated[0]
+    assert p.incomplete_suppression_coverage is False
+    assert p.violation_count == 19
+    assert p.passed is False
+
+
+# ── _count_unsuppressed ──────────────────────────────────────────
+
+
+def test_count_unsuppressed_coupling_ceiling():
+    """Filtered count excludes files in suppressed_keys."""
+    def resolver(cypher: str, **params):
+        if "suppressed_keys" in cypher and "count(f) AS v" in cypher:
+            return [{"v": 3}]
+        if "count(f) AS v" in cypher:
+            return [{"v": 5}]
+        return []
+
+    driver = _FakeDriver(resolver)
+    config = ArchConfig()
+    result = _count_unsuppressed(driver, "coupling_ceiling", ["a.ts", "b.ts"], None, config)
+    assert result == 3
+
+
+def test_count_unsuppressed_cross_package():
+    """Filtered count for cross_package per-pair queries."""
+    def resolver(cypher: str, **params):
+        if "suppressed_keys" in cypher:
+            return [{"v": 1}]
+        return [{"v": 3}]
+
+    driver = _FakeDriver(resolver)
+    config = ArchConfig(
+        cross_package=CrossPackageConfig(
+            pairs=[CrossPackagePair("web", "api")],
+        ),
+    )
+    result = _count_unsuppressed(
+        driver, "cross_package", ["web/a.ts -> api/b.ts"], None, config,
+    )
+    assert result == 1
+
+
+def test_count_unsuppressed_layer_bypass():
+    """Filtered count uses key format 'ctrl -> repo.method'."""
+    def resolver(cypher: str, **params):
+        if "suppressed_keys" in cypher and "count(DISTINCT ctrl)" in cypher:
+            return [{"v": 0}]
+        return [{"v": 2}]
+
+    driver = _FakeDriver(resolver)
+    config = ArchConfig()
+    result = _count_unsuppressed(
+        driver, "layer_bypass", ["UserCtrl -> UserRepo.find"], None, config,
+    )
+    assert result == 0
+
+
+def test_count_unsuppressed_orphan_detection():
+    """Filtered count for orphan_detection uses 'kind:name' format."""
+    def resolver(cypher: str, **params):
+        if "suppressed_keys" in cypher and "count(*) AS v" in cypher:
+            return [{"v": 1}]
+        return [{"v": 3}]
+
+    driver = _FakeDriver(resolver)
+    config = ArchConfig()
+    result = _count_unsuppressed(
+        driver, "orphan_detection", ["orphan_function:dead_fn"], None, config,
+    )
+    assert result == 1
+
+
+def test_count_unsuppressed_import_cycles_edge_key():
+    """Edge-pair keys (A -> B) produce NONE(...) filter in Cypher."""
+    captured: list[str] = []
+
+    def resolver(cypher: str, **params):
+        captured.append(cypher)
+        if "edge_pairs" in cypher:
+            return [{"v": 2}]
+        return [{"v": 5}]
+
+    driver = _FakeDriver(resolver)
+    config = ArchConfig()
+    result = _count_unsuppressed(
+        driver, "import_cycles", ["a.py -> b.py"], None, config,
+    )
+    assert result == 2
+    assert any("edge_pairs" in c for c in captured)
+
+
+def test_count_unsuppressed_import_cycles_full_cycle_key():
+    """Full-cycle keys produce NOT reduce(...) IN filter in Cypher."""
+    captured: list[str] = []
+
+    def resolver(cypher: str, **params):
+        captured.append(cypher)
+        if "full_cycle_keys" in cypher:
+            return [{"v": 0}]
+        return [{"v": 1}]
+
+    driver = _FakeDriver(resolver)
+    config = ArchConfig()
+    result = _count_unsuppressed(
+        driver, "import_cycles", ["a.py -> b.py -> a.py"], None, config,
+    )
+    assert result == 0
+    assert any("full_cycle_keys" in c for c in captured)
+
+
+def test_count_unsuppressed_custom_returns_none():
+    """Custom policies return None — caller falls back to Python counting."""
+    driver = _FakeDriver(lambda *a, **kw: [])
+    config = ArchConfig()
+    result = _count_unsuppressed(driver, "my_custom_rule", ["x"], None, config)
+    assert result is None
+
+
+def test_count_unsuppressed_with_scope():
+    """Scope params are threaded into the filtered count query."""
+    captured_params: list[dict] = []
+
+    def resolver(cypher: str, **params):
+        captured_params.append(params)
+        return [{"v": 0}]
+
+    driver = _FakeDriver(resolver)
+    config = ArchConfig()
+    _count_unsuppressed(
+        driver, "coupling_ceiling", ["a.ts"], ["src/"], config,
+    )
+    assert any(p.get("_scope0") == "src/" for p in captured_params)
+
+
 # ── Integration: run_arch_check + suppressions ──────────────────
 
 
 def test_run_arch_check_with_suppressions_exits_zero(monkeypatch):
     """All violations suppressed → report.ok is True."""
     sample = [{"file": "god.ts", "deps": 50}]
-    fake_driver = _constant_driver({
-        "count(DISTINCT path) AS v": [{"v": 0}],
-        "count(*) AS v": [{"v": 0}],
-        "count(DISTINCT ctrl) AS v": [{"v": 0}],
-        "count(f) AS v": [{"v": 1}],
-        "f.path AS file, deps": sample,
-    })
+
+    def resolver(cypher: str, **params):
+        # Filtered count query (from _count_unsuppressed) → 0 unsuppressed.
+        if "suppressed_keys" in cypher:
+            return [{"v": 0}]
+        if "count(DISTINCT path) AS v" in cypher:
+            return [{"v": 0}]
+        if "count(*) AS v" in cypher:
+            return [{"v": 0}]
+        if "count(DISTINCT ctrl) AS v" in cypher:
+            return [{"v": 0}]
+        if "count(f) AS v" in cypher:
+            return [{"v": 1}]
+        if "f.path AS file, deps" in cypher:
+            return sample
+        return []
+
+    fake_driver = _FakeDriver(resolver)
     monkeypatch.setattr(arch_check.GraphDatabase, "driver", lambda uri, auth: fake_driver)
 
     config = ArchConfig(
@@ -1101,13 +1353,24 @@ def test_run_arch_check_with_suppressions_exits_zero(monkeypatch):
 def test_run_arch_check_suppressions_in_json(monkeypatch):
     """JSON output includes suppressed_count and stale_suppressions."""
     sample = [{"file": "god.ts", "deps": 50}]
-    fake_driver = _constant_driver({
-        "count(DISTINCT path) AS v": [{"v": 0}],
-        "count(*) AS v": [{"v": 0}],
-        "count(DISTINCT ctrl) AS v": [{"v": 0}],
-        "count(f) AS v": [{"v": 1}],
-        "f.path AS file, deps": sample,
-    })
+
+    def resolver(cypher: str, **params):
+        # Filtered count query → 0 unsuppressed.
+        if "suppressed_keys" in cypher:
+            return [{"v": 0}]
+        if "count(DISTINCT path) AS v" in cypher:
+            return [{"v": 0}]
+        if "count(*) AS v" in cypher:
+            return [{"v": 0}]
+        if "count(DISTINCT ctrl) AS v" in cypher:
+            return [{"v": 0}]
+        if "count(f) AS v" in cypher:
+            return [{"v": 1}]
+        if "f.path AS file, deps" in cypher:
+            return sample
+        return []
+
+    fake_driver = _FakeDriver(resolver)
     monkeypatch.setattr(arch_check.GraphDatabase, "driver", lambda uri, auth: fake_driver)
 
     config = ArchConfig(
@@ -1138,6 +1401,45 @@ def test_run_arch_check_suppressions_in_json(monkeypatch):
     assert len(blob["stale_suppressions"]) == 1
     assert blob["stale_suppressions"][0]["policy"] == "import_cycles"
     assert blob["stale_suppressions"][0]["key"] == "x.py -> y.py"
+
+
+def test_run_arch_check_suppression_exact_count_integration(monkeypatch):
+    """End-to-end: 50 coupling_ceiling violations, all suppressed → count=0."""
+    sample = [{"file": f"f{i}.ts", "deps": 20 + i} for i in range(10)]
+
+    def resolver(cypher: str, **params):
+        # Filtered count → 0 unsuppressed.
+        if "suppressed_keys" in cypher:
+            return [{"v": 0}]
+        if "count(DISTINCT path) AS v" in cypher:
+            return [{"v": 0}]
+        if "count(*) AS v" in cypher:
+            return [{"v": 0}]
+        if "count(DISTINCT ctrl) AS v" in cypher:
+            return [{"v": 0}]
+        if "count(f) AS v" in cypher:
+            return [{"v": 50}]  # 50 total violations
+        if "f.path AS file, deps" in cypher:
+            return sample  # only 10 in sample
+        return []
+
+    fake_driver = _FakeDriver(resolver)
+    monkeypatch.setattr(arch_check.GraphDatabase, "driver", lambda uri, auth: fake_driver)
+
+    config = ArchConfig(
+        suppressions=[
+            Suppression(policy="coupling_ceiling", key=f"f{i}.ts", reason="ok")
+            for i in range(50)
+        ],
+    )
+    report = run_arch_check(
+        "bolt://fake:7687", "neo4j", "pw", console=None, config=config,
+    )
+    assert report.ok is True
+    coupling = next(p for p in report.policies if p.name == "coupling_ceiling")
+    assert coupling.violation_count == 0  # exact, not 50-10=40
+    assert coupling.passed is True
+    assert coupling.incomplete_suppression_coverage is False
 
 
 # ── CLI auto-scope tests ──────────────────────────────────────────────


### PR DESCRIPTION
Closes #93

## Summary
- Introduced `_count_unsuppressed()` dispatcher + 5 dedicated Cypher COUNT queries (coupling_ceiling, cross_package, layer_bypass, orphan_detection, import_cycles) with `NOT IN $suppressed_keys` filters embedded in WHERE — no more sample-window guessing
- Threaded the Neo4j driver through `run_arch_check()` → `_apply_suppressions()` so counts are available before the driver closes
- Custom policies fall back to the existing sample-based subtraction
- `incomplete=False` always when an exact count is returned; stale-suppression assertion invariant removed

## Test plan
- [x] Unit tests: 573 passed
- [x] Byte-compile clean
- [x] Code review: clean
- [x] Critique: PASS
- [x] Self-index verified (42 files, 90 classes, 297 methods)
- [x] Leytongo real-world test (1343 files, 72.9% imports resolved)
- [x] Arch-check: PASS (4/4 policies)

## Package
PyPI: `cognitx-codegraph==0.1.72`
Install: `pip install cognitx-codegraph==0.1.72`

Generated with [Claude Code](https://claude.com/claude-code)